### PR TITLE
Fixed all warnings.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/LoggablePlugin.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/LoggablePlugin.java
@@ -7,8 +7,6 @@
 
 package com.onarandombox.MultiverseCore;
 
-import com.pneumaticraft.commandhandler.Command;
-
 /**
  * Dummy class to make old MV Plugins not explode.
  * If this loads, the user WILL get a severe telling them to update said plugin!

--- a/src/main/java/com/onarandombox/MultiverseCore/MVPermissions.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MVPermissions.java
@@ -7,10 +7,6 @@
 
 package com.onarandombox.MultiverseCore;
 
-import com.pneumaticraft.commandhandler.Command;
-import org.bukkit.permissions.Permission;
-import org.bukkit.permissions.PermissionDefault;
-
 /**
  * Dummy class to make old MV Plugins not explode.
  * If this loads, the user WILL get a severe telling them to update said plugin!

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -38,7 +38,6 @@ import org.bukkit.util.config.Configuration;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/src/main/java/com/onarandombox/MultiverseCore/event/MVVersionRequestEvent.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/event/MVVersionRequestEvent.java
@@ -11,6 +11,11 @@ import org.bukkit.event.Event;
 
 public class MVVersionRequestEvent extends Event {
 
+    /**
+     * Auto-generated ID
+     */
+    private static final long serialVersionUID = 8069053313280257642L;
+    
     private String pasteBinBuffer;
 
     public MVVersionRequestEvent(String pasteBinBuffer) {

--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPluginListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPluginListener.java
@@ -9,7 +9,6 @@ package com.onarandombox.MultiverseCore.listeners;
 
 import com.fernferret.allpay.AllPay;
 import com.onarandombox.MultiverseCore.MultiverseCore;
-import com.onarandombox.MultiverseCore.api.MVPlugin;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.event.server.ServerListener;
@@ -26,6 +25,7 @@ public class MVPluginListener extends ServerListener {
     }
 
     /** Keep an eye out for Plugins which we can utilize. */
+    @SuppressWarnings("deprecation") //we need to use the deprecated MVPlugin here, it's not our fault and we know that it's deprecated
     @Override
     public void onPluginEnable(PluginEnableEvent event) {
         if(event.getPlugin() instanceof com.onarandombox.MultiverseCore.MVPlugin) {

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVMessaging.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVMessaging.java
@@ -21,6 +21,7 @@ import java.util.Map;
  * @author fernferret
  */
 public class MVMessaging {
+    @SuppressWarnings("unused") //maybe used in the future?
     private MultiverseCore plugin;
     private Map<String, Date> sentList;
     private int cooldown = 0;

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerSession.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerSession.java
@@ -15,10 +15,11 @@ import java.util.Date;
 
 public class MVPlayerSession {
 
+    @SuppressWarnings("unused") //maybe used in the future?
     private Player player; // Player holder, may be unnecessary.
 
     private Long teleportLast = 0L; // Timestamp for the Players last Portal Teleportation.
-    private Long messageLast = 0L; // Timestamp for the Players last Alert Message.
+    //private Long messageLast = 0L; // Timestamp for the Players last Alert Message. We don't need this until now so we comment it out.
 
     private Configuration config; // Configuration file to find out Cooldown Timers.
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -98,6 +98,7 @@ public class WorldManager implements MVWorldManager {
      *
      * @return True if the plugin exists and is enabled, false if not.
      */
+    @SuppressWarnings("unused")
     private boolean pluginExists(String generator) {
         Plugin plugin = this.plugin.getServer().getPluginManager().getPlugin(generator);
         return plugin != null && plugin.isEnabled();

--- a/src/main/java/com/onarandombox/utils/DestinationFactory.java
+++ b/src/main/java/com/onarandombox/utils/DestinationFactory.java
@@ -9,10 +9,6 @@ package com.onarandombox.utils;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.utils.MVDestination;
-import org.bukkit.Location;
-import org.bukkit.entity.Entity;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.util.Vector;
 
 /**
  * Dummy class to make old MV Plugins not explode.


### PR DESCRIPTION
Fixed ALL those warnings, caused by unused imports, unused variables, unused methods and deprecated stuff:
Removed the imports, suppressed the warning about that deprecation (since it's not the plugin's fault that it has to use deprecated code here) and either commented the unused stuff out or suppressed the warnings.
