### PR TITLE
Add extra null check on world colored string fetch

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MVWorld.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MVWorld.java
@@ -214,7 +214,14 @@ public class MVWorld implements MultiverseWorld {
     public String getColoredWorldString() {
         EnglishChatColor worldColor = ((ColorConfigProperty) this.getKnownProperty("color")).getValue();
         String alias = ((StringConfigProperty) this.getKnownProperty("alias")).getValue();
-        if (worldColor == null || worldColor.getColor() == null) {
+        if (worldColor == null) {
+            try {
+                this.setProperty("color", "WHITE");
+            } catch(PropertyDoesNotExistException e) {
+                // Do nothing - fixing the config file just failed, but we can recover anyway
+            }
+            return alias + ChatColor.WHITE;
+        } else if (worldColor.getColor() == null) {
             return alias + ChatColor.WHITE;
         }
         if (alias.length() == 0) {


### PR DESCRIPTION
This fixes the NPE pasted [here](http://pastebin.com/qShxwHmr) by IRC user `gartral` by adding a bonus null check. (Note that without repro conditions provided, it's largely untested, but should be safe to pull and have Jenkins build for user testing.)
