### PR TITLE
Fixed Importing from a world container directory which is not the default

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
@@ -106,7 +106,7 @@ public class ImportCommand extends MultiverseCommand {
             this.showHelp(sender);
             return;
         }
-        File worldFile = new File(this.plugin.getServerFolder(), worldName);
+        File worldFile = new File(this.plugin.getServer().getWorldContainer(), worldName);
         if (this.worldManager.isMVWorld(worldName) && worldFile.exists()) {
             sender.sendMessage(ChatColor.RED + "Multiverse already knows about this world!");
             return;


### PR DESCRIPTION
Changed runCommand to look in world container directory (defined in bukkit.yml) instead of in the server folder when attempting to import world files.
