### PR TITLE
Initial support for lists of language strings

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/localization/MessageProvider.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/localization/MessageProvider.java
@@ -17,35 +17,39 @@ public interface MessageProvider {
      * Returns a message (as {@link String}) for the specified key (as {@link MultiverseMessage}).
      *
      * @param key The key
+     * @param args Args for String.format()
      * @return The message
      */
-    public String getMessage(MultiverseMessage key);
+    public String getMessage(MultiverseMessage key, Object... args);
 
     /**
      * Returns a message (as {@link String}) in a specified {@link Locale} for the specified key (as {@link MultiverseMessage}).
      *
      * @param key The Key
      * @param locale The {@link Locale}
+     * @param args Args for String.format()
      * @return The message
      */
-    public String getMessage(MultiverseMessage key, Locale locale);
-    
+    public String getMessage(MultiverseMessage key, Locale locale, Object... args);
+
     /**
      * Returns a message (as {@link List}) of Strings for the specified key (as {@link MultiverseMessage}).
      *
      * @param key The key
+     * @param args Args for String.format()
      * @return The messages
      */
-    public List<String> getMessages(MultiverseMessage key);
+    public List<String> getMessages(MultiverseMessage key, Object... args);
 
     /**
      * Returns a message (as {@link List}) of Strings in a specified {@link Locale} for the specified key (as {@link MultiverseMessage}).
      *
      * @param key The key
      * @param locale The {@link Locale}
+     * @param args Args for String.format()
      * @return The messages
      */
-    public List<String> getMessages(MultiverseMessage key, Locale locale);
+    public List<String> getMessages(MultiverseMessage key, Locale locale, Object... args);
 
     /**
      * Returns the Locale this MessageProvider is currently using.

--- a/src/main/java/com/onarandombox/MultiverseCore/localization/MessageProvider.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/localization/MessageProvider.java
@@ -29,6 +29,23 @@ public interface MessageProvider {
      * @return The message
      */
     public String getMessage(MultiverseMessage key, Locale locale);
+    
+    /**
+     * Returns a message (as {@link List}) of Strings for the specified key (as {@link MultiverseMessage}).
+     *
+     * @param key The key
+     * @return The messages
+     */
+    public List<String> getMessages(MultiverseMessage key);
+
+    /**
+     * Returns a message (as {@link List}) of Strings in a specified {@link Locale} for the specified key (as {@link MultiverseMessage}).
+     *
+     * @param key The key
+     * @param locale The {@link Locale}
+     * @return The messages
+     */
+    public List<String> getMessages(MultiverseMessage key, Locale locale);
 
     /**
      * Returns the Locale this MessageProvider is currently using.

--- a/src/main/java/com/onarandombox/MultiverseCore/localization/MultiverseMessage.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/localization/MultiverseMessage.java
@@ -23,16 +23,18 @@ public enum MultiverseMessage {
     LIST_TITLE("Multiverse World List"),
     LIST_NO_MATCH("No worlds matched your filter:");
 
-    private final String def;
+    private final List<String> def;
 
-    MultiverseMessage(String def) {
-        this.def = def;
+    MultiverseMessage(String def, String... extra) {
+        this.def = new ArrayList<String>();
+        this.def.add(def);
+        this.def.addAll(Arrays.asList(extra));
     }
 
     /**
      * @return This {@link MultiverseMessage}'s default-message
      */
-    public String getDefault() {
+    public List<String> getDefault() {
         return def;
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/localization/SimpleMessageProvider.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/localization/SimpleMessageProvider.java
@@ -45,6 +45,20 @@ public class SimpleMessageProvider implements LazyLocaleMessageProvider {
             throw new LocalizationLoadingException("Couldn't load the localization: "
                     + locale.toString(), locale);
     }
+    
+    public List<String> format(List<String> strings, Object... args) {
+        for (String string : strings) {
+            format(string, args);
+        }
+        return strings;
+    }
+
+    public String format(String string, Object... args) {
+        // Replaces & with the Section character
+        string = string.replaceAll("&", Character.toString((char) 167));
+
+        return String.format(string, args);
+    }
 
     /**
      * {@inheritDoc}
@@ -116,52 +130,52 @@ public class SimpleMessageProvider implements LazyLocaleMessageProvider {
      * {@inheritDoc}
      */
     @Override
-    public String getMessage(MultiverseMessage key) {
+    public String getMessage(MultiverseMessage key, Object... args) {
         if (!isLocaleLoaded(locale)) {
-            return key.getDefault().get(0);
+            return format(key.getDefault().get(0), args);
         }
         else
-            return messages.get(locale).get(key).get(0);
+            return format(messages.get(locale).get(key).get(0), args);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public String getMessage(MultiverseMessage key, Locale locale) {
+    public String getMessage(MultiverseMessage key, Locale locale, Object... args) {
         try {
             maybeLoadLocale(locale);
         } catch (LocalizationLoadingException e) {
             e.printStackTrace();
-            return getMessage(key);
+            return getMessage(key, args);
         }
-        return messages.get(locale).get(key).get(0);
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public List<String> getMessages(MultiverseMessage key) {
-        if (!isLocaleLoaded(locale)) {
-            return key.getDefault();
-        }
-        else
-            return messages.get(locale).get(key);
+        return format(messages.get(locale).get(key).get(0), args);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public List<String> getMessages(MultiverseMessage key, Locale locale) {
+    public List<String> getMessages(MultiverseMessage key, Object... args) {
+        if (!isLocaleLoaded(locale)) {
+            return format(key.getDefault(), args);
+        }
+        else
+            return format(messages.get(locale).get(key), args);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getMessages(MultiverseMessage key, Locale locale, Object... args) {
         try {
             maybeLoadLocale(locale);
         } catch (LocalizationLoadingException e) {
             e.printStackTrace();
-            return getMessages(key);
+            return format(getMessages(key), args);
         }
-        return messages.get(locale).get(key);
+        return format(messages.get(locale).get(key), args);
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/localization/SimpleMessageProvider.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/localization/SimpleMessageProvider.java
@@ -137,6 +137,32 @@ public class SimpleMessageProvider implements LazyLocaleMessageProvider {
         }
         return messages.get(locale).get(key).get(0);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getMessages(MultiverseMessage key) {
+        if (!isLocaleLoaded(locale)) {
+            return key.getDefault();
+        }
+        else
+            return messages.get(locale).get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getMessages(MultiverseMessage key, Locale locale) {
+        try {
+            maybeLoadLocale(locale);
+        } catch (LocalizationLoadingException e) {
+            e.printStackTrace();
+            return getMessages(key);
+        }
+        return messages.get(locale).get(key);
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
The default message providers still only returns one string, but it stores messages in a list.
