### PR TITLE
Prevent NPE when teleporting to a world not made by MV.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
@@ -191,6 +191,8 @@ public class MVPlayerListener implements Listener {
                 teleporter, teleporterName, teleportee.getName()));
         MultiverseWorld fromWorld = this.worldManager.getMVWorld(event.getFrom().getWorld().getName());
         MultiverseWorld toWorld = this.worldManager.getMVWorld(event.getTo().getWorld().getName());
+        if (fromWorld == null || toWorld == null)
+            return;
         if (event.getFrom().getWorld().equals(event.getTo().getWorld())) {
             // The player is Teleporting to the same world.
             this.plugin.log(Level.FINER, String.format("Player '%s' is teleporting to the same world.",


### PR DESCRIPTION
I create worlds through code a lot. This throws NPEs when players teleport to the new world.
