### PR TITLE
Load Multiverse-Core on STARTUP. This should fix a lot of plugins that rely on worlds being loaded after POSTWORLD.

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: Multiverse-Core
 main: com.onarandombox.MultiverseCore.MultiverseCore
 authors: ['Rigby', 'fernferret', 'lithium3141', 'main--']
 version: maven-version-number
+load: STARTUP
 commands:
   mv:
     description: Generic Multiverse Command


### PR DESCRIPTION
I'm not sure why this wasn't added already, as quite a few plugins rely on all Worlds being loaded on POSTWORLD.
