### PR TITLE
Add player limit per world. Addresses #727

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MVWorld.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MVWorld.java
@@ -76,6 +76,7 @@ public class MVWorld extends SerializationConfig implements MultiverseWorld {
         PROPERTY_ALIASES.put("mode", "gameMode");
         PROPERTY_ALIASES.put("diff", "difficulty");
         PROPERTY_ALIASES.put("spawnlocation", "spawn");
+        PROPERTY_ALIASES.put("limit", "playerLimit");
         PROPERTY_ALIASES.put("animals", "spawning.animals.spawn");
         PROPERTY_ALIASES.put("monsters", "spawning.monsters.spawn");
         PROPERTY_ALIASES.put("animalsrate", "spawning.animals.spawnrate");
@@ -473,12 +474,15 @@ public class MVWorld extends SerializationConfig implements MultiverseWorld {
     private volatile long seed;
     @Property
     private volatile String generator;
+    @Property
+    private volatile int playerLimit;
     // End of properties
     // --------------------------------------------------------------
 
     private Permission permission;
     private Permission exempt;
     private Permission ignoreperm;
+    private Permission limitbypassperm;
 
     public MVWorld(boolean fixSpawn) {
         super();
@@ -584,15 +588,21 @@ public class MVWorld extends SerializationConfig implements MultiverseWorld {
 
         this.exempt = new Permission("multiverse.exempt." + this.getName(),
                 "A player who has this does not pay to enter this world, or use any MV portals in it " + this.getName(), PermissionDefault.OP);
+        
+        this.limitbypassperm = new Permission("mv.bypass.playerlimit." + this.getName(),
+                "A player who can enter this world regardless of wether its full", PermissionDefault.OP);
         try {
             this.plugin.getServer().getPluginManager().addPermission(this.permission);
             this.plugin.getServer().getPluginManager().addPermission(this.exempt);
             this.plugin.getServer().getPluginManager().addPermission(this.ignoreperm);
+            this.plugin.getServer().getPluginManager().addPermission(this.limitbypassperm);
             // Add the permission and exempt to parents.
             this.addToUpperLists(this.permission);
 
             // Add ignore to it's parent:
             this.ignoreperm.addParent("mv.bypass.gamemode.*", true);
+            // Add limit bypass to it's parent
+            this.limitbypassperm.addParent("mv.bypass.playerlimit.*", true);
         } catch (IllegalArgumentException e) {
             this.plugin.log(Level.FINER, "Permissions nodes were already added for " + this.name);
         }
@@ -664,6 +674,7 @@ public class MVWorld extends SerializationConfig implements MultiverseWorld {
         this.bedRespawn = true;
         this.worldBlacklist = new ArrayList<String>();
         this.generator = null;
+        this.playerLimit = -1;
     }
 
     /**
@@ -921,6 +932,22 @@ public class MVWorld extends SerializationConfig implements MultiverseWorld {
     @Override
     public void setGenerator(String generator) {
         this.setPropertyValueUnchecked("generator", generator);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPlayerLimit() {
+        return this.playerLimit;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPlayerLimit(int limit) {
+        this.setPropertyValueUnchecked("playerLimit", limit);
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseWorld.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseWorld.java
@@ -620,6 +620,22 @@ public interface MultiverseWorld {
      * @param autoLoad True if players dying in this world respawn at their bed.
      */
     void setBedRespawn(boolean autoLoad);
+    
+    /**
+     * Sets the player limit for this world after which players without an override
+     * permission node will not be allowed in. A value of -1 or less signifies no limit
+     * 
+     * @param limit The new limit
+     */
+    void setPlayerLimit(int limit);
+
+    /**
+     * Gets the player limit for this world after which players without an override
+     * permission node will not be allowed in. A value of -1 or less signifies no limit
+     * 
+     * @return The player limit
+     */
+    int getPlayerLimit();
 
     /**
      * Same as {@link #getTime()}, but returns a string.

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/PermissionTools.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/PermissionTools.java
@@ -257,6 +257,25 @@ public class PermissionTools {
         }
         return true;
     }
+    
+    public boolean playerCanBypassPlayerLimit(MultiverseWorld toWorld, CommandSender teleporter, Player teleportee) {
+        
+        if (teleporter == null) {
+            teleporter = teleportee;
+        }
+        
+        if (!(teleporter instanceof Player)) {
+            return true;  
+        }
+        
+        MVPermissions perms = plugin.getMVPerms();
+        if (perms.hasPermission(teleportee, "mv.bypass.playerlimit." + toWorld.getName(), false)) {
+            return true;
+        } else {
+            teleporter.sendMessage("The world " + toWorld.getColoredWorldString() + " is full");
+            return false;
+        }
+    }
 
     /**
      * Checks to see if a player should bypass game mode restrictions.


### PR DESCRIPTION
Adds a limit, configuration node should be obvious.
Two new permission nodes:
- mv.bypass.playerlimit.WORLDNAME
- mv.bypass.playerlimit.*

Needs to be documented, may as well do it as part of #924
### This is untested.
