### PR TITLE
Set prefixchat to false by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
             <url>http://repo.onarandombox.com/content/groups/public</url>
         </repository>
         <repository>
-            <id>Bukkit Official</id>
-            <url>http://repo.bukkit.org/content/repositories/public</url>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
         <!-- Required for Metrics -->
         <repository>
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.2</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>maven-replacer-plugin</artifactId>
-                <version>1.3.8</version>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <phase>prepare-package</phase>
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>2.5</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.11</version>
+                <version>2.18.1</version>
                 <configuration>
                     <parallel>methods</parallel>
                     <threadCount>10</threadCount>
@@ -127,14 +127,14 @@
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
                         <artifactId>surefire-junit47</artifactId>
-                        <version>2.11</version>
+                        <version>2.16</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.10</version>
+                <version>2.12.1</version>
                 <configuration>
                     <enableRulesSummary>true</enableRulesSummary>
                     <configLocation>${project.basedir}/config/mv_checks.xml</configLocation>
@@ -143,7 +143,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -156,7 +156,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8.1</version>
+                <version>2.10.1</version>
                 <executions>
                     <execution>
                         <id>javadoc-jar</id>
@@ -170,7 +170,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>1.5</version>
+                <version>2.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -258,11 +258,11 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.7.2-R0.2</version>
+            <version>1.8-R0.1-SNAPSHOT</version>
             <!-- If you want the lates, use this -->
             <!-- <version>LATEST</version> -->
             <type>jar</type>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- Bukkit Dependency -->
         <!-- Start of Spout (disabled because we aren't using it)
@@ -291,10 +291,10 @@
         </dependency>
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
-            <artifactId>Vault</artifactId>
-            <version>1.2.27</version>
+            <artifactId>VaultAPI</artifactId>
+            <version>1.5</version>
             <type>jar</type>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- End of Economy Dependency -->
         <!-- Start of CommandHandler Dependency -->
@@ -337,33 +337,34 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.2</version>
+            <version>4.12</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.4.9</version>
+            <version>1.6.0</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-easymock</artifactId>
-            <version>1.4.9</version>
+            <version>1.6.1</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
-            <version>1.4.9</version>
+            <version>1.6.1</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.0</version>
+            <version>3.3.1</version>
             <scope>test</scope>
         </dependency>
         <!-- End of Test Dependencies -->

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
@@ -86,7 +86,7 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
         // BEGIN CHECKSTYLE-SUPPRESSION: MagicNumberCheck
         enforceaccess = false;
         useasyncchat = true;
-        prefixchat = true;
+        prefixchat = false;
         prefixchatformat = "[%world%]%chat%";
         teleportintercept = true;
         firstspawnoverride = true;

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/WhoCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/WhoCommand.java
@@ -52,7 +52,7 @@ public class WhoCommand extends MultiverseCommand {
             showAll = false;
         }
 
-        final Player[] onlinePlayers = plugin.getServer().getOnlinePlayers();
+        final Player[] onlinePlayers = (Player[]) plugin.getServer().getOnlinePlayers().toArray();
         final Collection<Player> visiblePlayers = new HashSet<Player>(onlinePlayers.length);
         for (final Player player : onlinePlayers) {
             if (p == null || p.canSee(player)) {

--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
@@ -161,6 +161,12 @@ public class MVPlayerListener implements Listener {
         if (event.isCancelled()) {
             return;
         }
+        if (event.getTo() == null) {
+            // For some reason, since Spigot 1.8.3, an errant teleport event with no destination may fire from nether portal
+            this.plugin.log(Level.FINE, "No destination set, teleportation request cancelled.");
+            event.setCancelled(true);
+            return;
+        }
         Player teleportee = event.getPlayer();
         CommandSender teleporter = null;
         String teleporterName = MultiverseCore.getPlayerTeleporter(teleportee.getName());

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -368,9 +368,9 @@ public class WorldManager implements MVWorldManager {
     }
 
     private void brokenWorld(String name) {
-        this.plugin.log(Level.SEVERE, "The world '" + name + "' could NOT be loaded because it contains errors!");
-        this.plugin.log(Level.SEVERE, "Try using Chukster to repair your world! '" + name + "'");
-        this.plugin.log(Level.SEVERE, "http://forums.bukkit.org/threads/admin-chunkster.8186/");
+        this.plugin.log(Level.SEVERE, "The world '" + name + "' could NOT be loaded because it contains errors and is probably corrupt!");
+        this.plugin.log(Level.SEVERE, "Try using Minecraft Region Fixer to repair your world! '" + name + "'");
+        this.plugin.log(Level.SEVERE, "https://github.com/Fenixin/Minecraft-Region-Fixer");
     }
 
     private boolean doLoad(String name) {


### PR DESCRIPTION
Made prefixchat default to false.
This will mean server owners don't have to type /mv conf prefixchat false when they start up a server.
This PR is purely for ease as apposed to a feature.