### PR TITLE
fixed issue number 1579

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/destination/ExactDestination.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/ExactDestination.java
@@ -187,8 +187,9 @@ public class ExactDestination implements MVDestination {
         if (location != null) {
             this.location = location;
             this.isValid = true;
-        }
+        }else{
         this.isValid = false;
+		}
     }
 
     /**


### PR DESCRIPTION
You see, in the Class Exact location, You have the method setExactLocation(Location location).
the contents now are as follows:

       if (location != null) {
            this.location = location;
            this.isValid = true;
        }
        this.isValid = false;
because the statement this.isValid = false is outside the if block, there is no way to set a valid location with this method. 
I added an else{} branch after the if containing the this.isValid statement. This makes the location setting once again possible via Bukkit locations.