### PR TITLE
RFC:  Teleport to players' last locations in worlds

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -59,6 +59,7 @@ import com.onarandombox.MultiverseCore.destination.BedDestination;
 import com.onarandombox.MultiverseCore.destination.CannonDestination;
 import com.onarandombox.MultiverseCore.destination.DestinationFactory;
 import com.onarandombox.MultiverseCore.destination.ExactDestination;
+import com.onarandombox.MultiverseCore.destination.LastLocationDestination;
 import com.onarandombox.MultiverseCore.destination.PlayerDestination;
 import com.onarandombox.MultiverseCore.destination.WorldDestination;
 import com.onarandombox.MultiverseCore.event.MVVersionEvent;
@@ -459,6 +460,7 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
         this.destFactory.registerDestinationType(WorldDestination.class, "");
         this.destFactory.registerDestinationType(WorldDestination.class, "w");
         this.destFactory.registerDestinationType(ExactDestination.class, "e");
+        this.destFactory.registerDestinationType(LastLocationDestination.class, LastLocationDestination.getID());
         this.destFactory.registerDestinationType(PlayerDestination.class, "pl");
         this.destFactory.registerDestinationType(CannonDestination.class, "ca");
         this.destFactory.registerDestinationType(BedDestination.class, "b");

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -208,6 +208,7 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
     private CommandHandler commandHandler;
 
     private static final String LOG_TAG = "[Multiverse-Core]";
+    public  static final String PLAYER_LOCATION_DATA = "player_location_data";
 
     // Multiverse Permissions Handler
     private MVPermissions ph;

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -76,6 +76,7 @@ import com.onarandombox.MultiverseCore.utils.AnchorManager;
 import com.onarandombox.MultiverseCore.utils.MVEconomist;
 import com.onarandombox.MultiverseCore.utils.MVMessaging;
 import com.onarandombox.MultiverseCore.utils.MVPermissions;
+import com.onarandombox.MultiverseCore.utils.MVPlayerLocation;
 import com.onarandombox.MultiverseCore.utils.MVPlayerSession;
 import com.onarandombox.MultiverseCore.utils.SimpleBlockSafety;
 import com.onarandombox.MultiverseCore.utils.SimpleLocationManipulation;
@@ -208,7 +209,6 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
     private CommandHandler commandHandler;
 
     private static final String LOG_TAG = "[Multiverse-Core]";
-    public  static final String PLAYER_LOCATION_DATA = "player_location_data";
 
     // Multiverse Permissions Handler
     private MVPermissions ph;
@@ -259,6 +259,8 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
         // Setup our SafeTTeleporter
         this.safeTTeleporter = new SimpleSafeTTeleporter(this);
         this.unsafeCallWrapper = new UnsafeCallWrapper(this);
+        // Set up MVPlayerLocation
+        MVPlayerLocation.init(this);
     }
 
 

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CheckCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CheckCommand.java
@@ -43,7 +43,7 @@ public class CheckCommand extends MultiverseCommand {
             sender.sendMessage("Are they online?");
             return;
         }
-        MVDestination dest = this.plugin.getDestFactory().getDestination(args.get(1));
+        MVDestination dest = this.plugin.getDestFactory().getDestination(args.get(1), sender, p);
         if (dest instanceof InvalidDestination) {
             sender.sendMessage(String.format("You asked if '%s' could go to %s%s%s,",
                     args.get(0), ChatColor.GREEN, args.get(0), ChatColor.WHITE));

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
@@ -88,7 +88,7 @@ public class TeleportCommand extends MultiverseCommand {
 
         }
         DestinationFactory df = this.plugin.getDestFactory();
-        MVDestination d = df.getDestination(destinationName, teleportee);
+        MVDestination d = df.getDestination(destinationName, teleporter, teleportee);
 
 
         MVTeleportEvent teleportEvent = new MVTeleportEvent(d, teleportee, teleporter, true);

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
@@ -88,7 +88,7 @@ public class TeleportCommand extends MultiverseCommand {
 
         }
         DestinationFactory df = this.plugin.getDestFactory();
-        MVDestination d = df.getDestination(destinationName);
+        MVDestination d = df.getDestination(destinationName, teleportee);
 
 
         MVTeleportEvent teleportEvent = new MVTeleportEvent(d, teleportee, teleporter, true);

--- a/src/main/java/com/onarandombox/MultiverseCore/destination/DestinationFactory.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/DestinationFactory.java
@@ -12,12 +12,18 @@ import com.onarandombox.MultiverseCore.api.MVDestination;
 import com.onarandombox.MultiverseCore.commands.TeleportCommand;
 import com.onarandombox.MultiverseCore.utils.PermissionTools;
 import com.pneumaticraft.commandhandler.Command;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.Location;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.Map;
+import java.util.zip.DataFormatException;
 
 /** A factory class that will create destinations from specific strings. */
 public class DestinationFactory {
@@ -37,17 +43,101 @@ public class DestinationFactory {
     }
 
     /**
-     * Gets a new destination from a string.
+     * Gets a new destination from a string and possibly for a player.
      * Returns a new InvalidDestination if the string could not be parsed.
      *
      * @param destination The destination in string format.
+     * @param player The player.
      *
      * @return A non-null MVDestination
      */
-    public MVDestination getDestination(String destination) {
+    public MVDestination getDestination(String destination, Player player) {
         String idenChar = "";
         if (destination.split(":").length > 1) {
             idenChar = destination.split(":")[0];
+        }
+
+        if (idenChar.equals("") && player != null && this.plugin.getMVWorldManager().isMVWorld(destination)) {
+            // handle special case
+            String playerID = player.getUniqueId().toString();
+            File f = new File(this.plugin.getDataFolder(), MultiverseCore.PLAYER_LOCATION_DATA
+                + File.separator + destination + File.separator + playerID + ".yaml");
+            if (f.isFile()) {
+                YamlConfiguration yc = new YamlConfiguration();
+                try {
+                    yc.load(f);
+                } catch (Exception e) {
+                    this.plugin.log(Level.SEVERE, "Failed to load saved location of player '"
+                        + player.getName() + "' (" + playerID + ") in world '" + destination
+                        + "': " + e.getMessage() + ".");
+                    yc = null;
+                    // fall through to use world spawn location
+                }
+                if (yc != null) {
+                    try {
+                        if (! yc.isSet("schema"))
+                            throw new DataFormatException("missing schema node");
+                        Object schema = yc.get("schema");
+                        if (! Integer.class.isInstance(schema))
+                            throw new DataFormatException("invalid schema version: "
+                                + schema.toString());
+                        if ((Integer) schema != 1)
+                            throw new DataFormatException("invalid schema version: "
+                                + schema.toString());
+
+                        if (! yc.isSet("x"))
+                            throw new DataFormatException("missing x location");
+                        Object x = yc.get("x");
+                        if (! Double.class.isInstance(x))
+                            throw new DataFormatException("invalid data for x location: "
+                                + x.toString());
+
+                        if (! yc.isSet("y"))
+                            throw new DataFormatException("missing y location");
+                        Object y = yc.get("y");
+                        if (! Double.class.isInstance(y))
+                            throw new DataFormatException("invalid data for y location: "
+                                + y.toString());
+
+                        if (! yc.isSet("z"))
+                            throw new DataFormatException("missing z location");
+                        Object z = yc.get("z");
+                        if (! Double.class.isInstance(z))
+                            throw new DataFormatException("invalid data for z location: "
+                                + z.toString());
+
+                        if (! yc.isSet("yaw"))
+                            throw new DataFormatException("missing yaw");
+                        Object yaw = yc.get("yaw");
+                        if (! Double.class.isInstance(yaw))
+                            throw new DataFormatException("invalid data for yaw: "
+                                + yaw.toString());
+
+                        if (! yc.isSet("pitch"))
+                            throw new DataFormatException("missing pitch");
+                        Object pitch = yc.get("pitch");
+                        if (! Double.class.isInstance(pitch))
+                            throw new DataFormatException("invalid data for pitch: "
+                                + pitch.toString());
+
+                        MVDestination mydest = new ExactDestination();
+                        ((ExactDestination) mydest).setDestination(new Location(
+                            this.plugin.getMVWorldManager().getMVWorld(destination).getCBWorld(),
+                            ((Double) x).doubleValue(), ((Double) y).doubleValue(), ((Double) z).doubleValue(),
+                            ((Double) yaw).floatValue(), ((Double) pitch).floatValue()));
+                        return mydest;
+
+                    } catch (DataFormatException e) {
+                        this.plugin.log(Level.SEVERE, "Failed to parse saved location of player '"
+                            + player.getName() + "' (" + playerID + ") in world '" + destination
+                            + "': " + e.getMessage() + ".");
+                        // fall through to use world spawn location
+                    }
+                }
+            } else {
+                this.plugin.log(Level.FINE, "No saved location for player '" + player.getName()
+                    + "' (" + playerID + ") in world '" + destination + "' found.");
+            }
         }
 
         if (this.destList.containsKey(idenChar)) {
@@ -64,6 +154,18 @@ public class DestinationFactory {
             }
         }
         return new InvalidDestination();
+    }
+
+    /**
+     * Gets a new destination from a string.
+     * Returns a new InvalidDestination if the string could not be parsed.
+     *
+     * @param destination The destination in string format.
+     *
+     * @return A non-null MVDestination
+     */
+    public MVDestination getDestination(String destination) {
+        return getDestination(destination, null);
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/destination/LastLocationDestination.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/LastLocationDestination.java
@@ -1,0 +1,228 @@
+/******************************************************************************
+ * Multiverse 2 Copyright (c) the Multiverse Team 2011.                       *
+ * Multiverse 2 is licensed under the BSD License.                            *
+ * For more information please check the README.md file included              *
+ * with this project.                                                         *
+ ******************************************************************************/
+
+package com.onarandombox.MultiverseCore.destination;
+
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MultiverseWorld;
+import com.onarandombox.MultiverseCore.api.MVDestination;
+import com.onarandombox.MultiverseCore.utils.MVPlayerLocation;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.Vector;
+
+/**
+ * An exact {@link MVDestination}.
+ */
+public class LastLocationDestination implements MVDestination {
+    private String direction = "";
+    private boolean isSpawn;
+    private Location location = null;
+    private Player player = null;
+    private MultiverseWorld world = null;
+    private float yaw = 0;
+
+    //  The internal state of an instance is in a superposition much like
+    //  Schrödinger's cat.  Until observed via getLocation(Entity), the
+    //  instance is both a player's last location in the world and the location
+    //  of the spawn point in the world.  The superposition does not collapse
+    //  into one or the other state until being observed via
+    //  getLocation(Entity).  This is a result of how the MVDestination
+    //  interface is defined.
+    //  (Although, technially it is a superposition of not having the player's
+    //  last location and not having the spawn location until being observed.)
+
+    public static String getID() {
+        return "l";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getIdentifier() {
+        return this.getID();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Vector getVelocity() {
+        return new Vector(0, 0, 0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isThisType(JavaPlugin plugin, String destination) {
+        if (!(plugin instanceof MultiverseCore)) {
+            return false;
+        }
+
+        // Need one of the following:
+        //   world
+        //   world:direction
+        //   l:world
+        //   l:world:direction
+        String[] items = destination.split(":");
+        if (items.length < 1 || items.length > 3) {
+            return false;
+        }
+        if (items.length == 1) {
+            if (((MultiverseCore) plugin).getMVWorldManager().isMVWorld(items[0])) {
+                // world
+                return true;
+            }
+        } else if (items.length == 2 && ((MultiverseCore) plugin).getMVWorldManager().isMVWorld(items[0])) {
+            // world:direction
+            return true;
+        } else if (items[0].equalsIgnoreCase(this.getIdentifier()) && ((MultiverseCore) plugin).getMVWorldManager().isMVWorld(items[1])) {
+            // l:world  OR  l:world:direction
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Location getLocation(Entity e) {
+        if (!this.isValid() || e == null || !(e instanceof Player)) {
+            return null;
+        }
+
+        player = (Player) e;
+        this.location = MVPlayerLocation.getPlayerLastLocation(player, world);
+
+        if (this.location == null) {
+            this.location = world.getSpawnLocation();
+            this.location.setYaw(this.yaw);
+            this.isSpawn = true;
+        } else {
+            this.isSpawn = false;
+        }
+
+        return this.location;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isValid() {
+        return this.world != null;
+    }
+
+    public boolean isSpawn() {
+        return this.isSpawn;
+    }
+
+    public boolean isCollapsed() {
+        return this.location != null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDestination(JavaPlugin plugin, String destination) {
+        this.direction = "";
+        this.location = null;
+        this.player = null;
+        this.world = null;
+        this.yaw = 0;
+
+        if (!(plugin instanceof MultiverseCore)) {
+            return;
+        }
+
+        // Need one of the following:
+        //   world
+        //   world:direction
+        //   l:world
+        //   l:world:direction
+        String[] items = destination.split(":");
+        if (items.length < 1 || items.length > 3) {
+            return;
+        }
+        if (items.length == 1) {
+            if (((MultiverseCore) plugin).getMVWorldManager().isMVWorld(items[0])) {
+                // world
+                this.world = ((MultiverseCore) plugin).getMVWorldManager().getMVWorld(items[0]);
+                return;
+            }
+        } else if (items.length == 2 && ((MultiverseCore) plugin).getMVWorldManager().isMVWorld(items[0])) {
+            // world:direction
+            this.world = ((MultiverseCore) plugin).getMVWorldManager().getMVWorld(items[0]);
+            this.direction = items[1];
+            return;
+        } else if (items[0].equalsIgnoreCase(this.getIdentifier()) && ((MultiverseCore) plugin).getMVWorldManager().isMVWorld(items[1])) {
+            // l:world  OR  l:world:direction
+            this.world = ((MultiverseCore) plugin).getMVWorldManager().getMVWorld(items[1]);
+            if (items.length == 3) {
+                this.direction = items[2];
+                this.yaw = ((MultiverseCore) plugin).getLocationManipulation().getYaw(this.direction);
+            }
+            return;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getType() {
+        return "Last Location";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        if (this.isValid()) {
+            return "Last Location ("
+                + (player != null ? player.getName() + " in " : "")
+                + this.world.getName() + ")";
+        }
+        return "Invalid Destination";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        if (this.isValid()) {
+            return this.getIdentifier() + ":" + this.world.getName() + (this.direction.length() > 0 ?
+                ":" + this.direction : "");
+        }
+        return "i:Invalid Destination";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getRequiredPermission() {
+        return "multiverse.access." + this.world.getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean useSafeTeleporter() {
+        return true;
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
@@ -11,6 +11,7 @@ import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
+import com.onarandombox.MultiverseCore.utils.MVPlayerLocation;
 import com.onarandombox.MultiverseCore.event.MVRespawnEvent;
 import com.onarandombox.MultiverseCore.utils.PermissionTools;
 import org.bukkit.GameMode;
@@ -18,7 +19,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -30,7 +30,6 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
-import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -49,47 +48,6 @@ public class MVPlayerListener implements Listener {
         this.plugin = plugin;
         worldManager = plugin.getMVWorldManager();
         pt = new PermissionTools(plugin);
-    }
-
-    private void savePlayerLocation(Player player, Location location, String action) {
-        String world    = location.getWorld().getName();
-        String playerID = player.getUniqueId().toString();
-
-        this.plugin.log(Level.FINE, "Player '" + player.getName()
-                + "' (" + playerID + ") was in world '" + world + "' at "
-                + Double.toString(location.getX()) + ", "
-                + Double.toString(location.getY()) + ", "
-                + Double.toString(location.getZ()) + ", "
-                + Double.toString(location.getYaw()) + ", "
-                + Double.toString(location.getPitch()) + " before " + action + ".");
-
-        YamlConfiguration yc = new YamlConfiguration();
-        yc.set("schema", 1);
-        yc.set("world", world);
-        yc.set("player", playerID);
-        yc.set("x", location.getX());
-        yc.set("y", location.getY());
-        yc.set("z", location.getZ());
-        yc.set("yaw", location.getYaw());
-        yc.set("pitch", location.getPitch());
-
-        File d = new File(this.plugin.getDataFolder(),
-            MultiverseCore.PLAYER_LOCATION_DATA + File.separator + world);
-
-        try {
-            d.mkdirs();
-        } catch (Exception e) {
-            this.plugin.log(Level.SEVERE, "Failed to create directory '"
-                + d.toString() + "': " + e.getMessage());
-        }
-
-        try {
-            yc.save(new File(d, playerID + ".yaml"));
-        } catch (Exception e) {
-            this.plugin.log(Level.SEVERE, "Failed to save location of player '"
-                + player.getName() + "' in world '" + world + "': "
-                + e.getMessage());
-        }
     }
 
     /**
@@ -192,7 +150,7 @@ public class MVPlayerListener implements Listener {
     public void playerQuit(PlayerQuitEvent event) {
         Player player = event.getPlayer();
         this.plugin.removePlayerSession(player);
-        savePlayerLocation(player, player.getLocation(), "quitting");
+        MVPlayerLocation.savePlayerLocation(player, player.getLocation(), "quitting");
     }
 
     /**
@@ -287,7 +245,7 @@ public class MVPlayerListener implements Listener {
     public void playerTeleportMonitor(PlayerTeleportEvent event) {
 
         if (! event.getFrom().getWorld().equals(event.getTo().getWorld())) {
-            savePlayerLocation(event.getPlayer(), event.getFrom(), "teleporting");
+            MVPlayerLocation.savePlayerLocation(event.getPlayer(), event.getFrom(), "teleporting");
         }
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerLocation.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerLocation.java
@@ -9,6 +9,7 @@ package com.onarandombox.MultiverseCore.utils;
 
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.api.MVDestination;
 import com.onarandombox.MultiverseCore.destination.ExactDestination;
 import org.bukkit.Location;
@@ -29,9 +30,9 @@ public class MVPlayerLocation {
     }
 
     private static class InvalidData extends Exception {
-	public InvalidData(String msg) {
-	    super(msg);
-	}
+        public InvalidData(String msg) {
+            super(msg);
+        }
     }
 
     public static void savePlayerLocation(Player player, Location location, String action) {
@@ -78,15 +79,17 @@ public class MVPlayerLocation {
         }
     }
 
-    public static MVDestination getPlayerLastLocation(Player player, String world) {
-        String playerID = player.getUniqueId().toString();
+    public static Location getPlayerLastLocation(Player player, MultiverseWorld world) {
+        String playerID;
         File   file;
 
-        if (plugin == null)
+        if (plugin == null || player.getUniqueId() == null)
             return null;
 
+        playerID = player.getUniqueId().toString();
+
         file = new File(plugin.getDataFolder(), PLAYER_LOCATION_DATA
-            + File.separator + world + File.separator + playerID + ".yaml");
+            + File.separator + world.getName() + File.separator + playerID + ".yaml");
 
         if (file.isFile()) {
             YamlConfiguration yc = new YamlConfiguration();
@@ -94,7 +97,7 @@ public class MVPlayerLocation {
                 yc.load(file);
             } catch (Exception e) {
                 plugin.log(Level.SEVERE, "Failed to load saved location of player '"
-                    + player.getName() + "' (" + playerID + ") in world '" + world
+                    + player.getName() + "' (" + playerID + ") in world '" + world.getName()
                     + "': " + e.getMessage() + ".");
                 return null;
             }
@@ -138,22 +141,18 @@ public class MVPlayerLocation {
                     throw new InvalidData("invalid data for pitch: "
                         + yc.get("pitch").toString());
 
-                MVDestination mydest = new ExactDestination();
-                ((ExactDestination) mydest).setDestination(new Location(
-                    plugin.getMVWorldManager().getMVWorld(world).getCBWorld(),
+                return new Location(world.getCBWorld(),
                     yc.getDouble("x"), yc.getDouble("y"), yc.getDouble("z"),
-                    (float) yc.getDouble("yaw"), (float) yc.getDouble("pitch")));
-                return mydest;
-
+                    (float) yc.getDouble("yaw"), (float) yc.getDouble("pitch"));
             } catch (InvalidData e) {
                 plugin.log(Level.SEVERE, "Failed to parse saved location of player '"
-                    + player.getName() + "' (" + playerID + ") in world '" + world
+                    + player.getName() + "' (" + playerID + ") in world '" + world.getName()
                     + "': " + e.getMessage() + ".");
                 return null;
             }
         } else {
             plugin.log(Level.FINE, "No saved location for player '" + player.getName()
-                + "' (" + playerID + ") in world '" + world + "' found.");
+                + "' (" + playerID + ") in world '" + world.getName() + "' found.");
             return null;
         }
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerLocation.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerLocation.java
@@ -1,0 +1,161 @@
+/******************************************************************************
+ * Multiverse 2 Copyright (c) the Multiverse Team 2011.                       *
+ * Multiverse 2 is licensed under the BSD License.                            *
+ * For more information please check the README.md file included              *
+ * with this project.                                                         *
+ ******************************************************************************/
+
+package com.onarandombox.MultiverseCore.utils;
+
+import com.dumptruckman.minecraft.util.Logging;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MVDestination;
+import com.onarandombox.MultiverseCore.destination.ExactDestination;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.zip.DataFormatException;
+
+public class MVPlayerLocation {
+
+    private static final String PLAYER_LOCATION_DATA = "player_location_data";
+
+    private static MultiverseCore plugin = null;
+
+    public static void init(MultiverseCore p) {
+        plugin = p;
+    }
+
+    public static void savePlayerLocation(Player player, Location location, String action) {
+        String world    = location.getWorld().getName();
+        String playerID = player.getUniqueId().toString();
+
+        if (plugin == null)
+            return;
+
+        plugin.log(Level.FINE, "Player '" + player.getName()
+                + "' (" + playerID + ") was in world '" + world + "' at "
+                + Double.toString(location.getX()) + ", "
+                + Double.toString(location.getY()) + ", "
+                + Double.toString(location.getZ()) + ", "
+                + Double.toString(location.getYaw()) + ", "
+                + Double.toString(location.getPitch()) + " before " + action + ".");
+
+        YamlConfiguration yc = new YamlConfiguration();
+        yc.set("schema", 1);
+        yc.set("world", world);
+        yc.set("player", playerID);
+        yc.set("x", location.getX());
+        yc.set("y", location.getY());
+        yc.set("z", location.getZ());
+        yc.set("yaw", location.getYaw());
+        yc.set("pitch", location.getPitch());
+
+        File dir = new File(plugin.getDataFolder(),
+            PLAYER_LOCATION_DATA + File.separator + world);
+
+        try {
+            dir.mkdirs();
+        } catch (Exception e) {
+            plugin.log(Level.SEVERE, "Failed to create directory '"
+                + dir.toString() + "': " + e.getMessage());
+        }
+
+        try {
+            yc.save(new File(dir, playerID + ".yaml"));
+        } catch (Exception e) {
+            plugin.log(Level.SEVERE, "Failed to save location of player '"
+                + player.getName() + "' in world '" + world + "': "
+                + e.getMessage());
+        }
+    }
+
+    public static MVDestination getPlayerLastLocation(Player player, String world) {
+        String playerID = player.getUniqueId().toString();
+        File   file;
+
+        if (plugin == null)
+            return null;
+
+        file = new File(plugin.getDataFolder(), PLAYER_LOCATION_DATA
+            + File.separator + world + File.separator + playerID + ".yaml");
+
+        if (file.isFile()) {
+            YamlConfiguration yc = new YamlConfiguration();
+            try {
+                yc.load(file);
+            } catch (Exception e) {
+                plugin.log(Level.SEVERE, "Failed to load saved location of player '"
+                    + player.getName() + "' (" + playerID + ") in world '" + world
+                    + "': " + e.getMessage() + ".");
+                return null;
+            }
+            try {
+                if (! yc.isSet("schema"))
+                    throw new DataFormatException("missing schema node");
+                Object schema = yc.get("schema");
+                if (! Integer.class.isInstance(schema))
+                    throw new DataFormatException("invalid schema version: "
+                        + schema.toString());
+                if ((Integer) schema != 1)
+                    throw new DataFormatException("invalid schema version: "
+                        + schema.toString());
+
+                if (! yc.isSet("x"))
+                    throw new DataFormatException("missing x location");
+                Object x = yc.get("x");
+                if (! Double.class.isInstance(x))
+                    throw new DataFormatException("invalid data for x location: "
+                        + x.toString());
+
+                if (! yc.isSet("y"))
+                    throw new DataFormatException("missing y location");
+                Object y = yc.get("y");
+                if (! Double.class.isInstance(y))
+                    throw new DataFormatException("invalid data for y location: "
+                        + y.toString());
+
+                if (! yc.isSet("z"))
+                    throw new DataFormatException("missing z location");
+                Object z = yc.get("z");
+                if (! Double.class.isInstance(z))
+                    throw new DataFormatException("invalid data for z location: "
+                        + z.toString());
+
+                if (! yc.isSet("yaw"))
+                    throw new DataFormatException("missing yaw");
+                Object yaw = yc.get("yaw");
+                if (! Double.class.isInstance(yaw))
+                    throw new DataFormatException("invalid data for yaw: "
+                        + yaw.toString());
+
+                if (! yc.isSet("pitch"))
+                    throw new DataFormatException("missing pitch");
+                Object pitch = yc.get("pitch");
+                if (! Double.class.isInstance(pitch))
+                    throw new DataFormatException("invalid data for pitch: "
+                        + pitch.toString());
+
+                MVDestination mydest = new ExactDestination();
+                ((ExactDestination) mydest).setDestination(new Location(
+                    plugin.getMVWorldManager().getMVWorld(world).getCBWorld(),
+                    ((Double) x).doubleValue(), ((Double) y).doubleValue(), ((Double) z).doubleValue(),
+                    ((Double) yaw).floatValue(), ((Double) pitch).floatValue()));
+                return mydest;
+
+            } catch (DataFormatException e) {
+                plugin.log(Level.SEVERE, "Failed to parse saved location of player '"
+                    + player.getName() + "' (" + playerID + ") in world '" + world
+                    + "': " + e.getMessage() + ".");
+                return null;
+            }
+        } else {
+            plugin.log(Level.FINE, "No saved location for player '" + player.getName()
+                + "' (" + playerID + ") in world '" + world + "' found.");
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerLocation.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerLocation.java
@@ -17,7 +17,6 @@ import org.bukkit.entity.Player;
 
 import java.io.File;
 import java.util.logging.Level;
-import java.util.zip.DataFormatException;
 
 public class MVPlayerLocation {
 
@@ -27,6 +26,12 @@ public class MVPlayerLocation {
 
     public static void init(MultiverseCore p) {
         plugin = p;
+    }
+
+    private static class InvalidData extends Exception {
+	public InvalidData(String msg) {
+	    super(msg);
+	}
     }
 
     public static void savePlayerLocation(Player player, Location location, String action) {
@@ -95,42 +100,42 @@ public class MVPlayerLocation {
             }
             try {
                 if (! yc.isSet("schema"))
-                    throw new DataFormatException("missing schema node");
+                    throw new InvalidData("missing schema node");
                 if (! yc.isInt("schema"))
-                    throw new DataFormatException("invalid schema version: "
+                    throw new InvalidData("invalid schema version: "
                         + yc.get("schema").toString());
                 if (yc.getInt("schema") != 1)
-                    throw new DataFormatException("invalid schema version: "
+                    throw new InvalidData("invalid schema version: "
                         + yc.get("schema").toString());
 
                 if (! yc.isSet("x"))
-                    throw new DataFormatException("missing x location");
+                    throw new InvalidData("missing x location");
                 if (! yc.isDouble("x"))
-                    throw new DataFormatException("invalid data for x location: "
+                    throw new InvalidData("invalid data for x location: "
                         + yc.get("x").toString());
 
                 if (! yc.isSet("y"))
-                    throw new DataFormatException("missing y location");
+                    throw new InvalidData("missing y location");
                 if (! yc.isDouble("y"))
-                    throw new DataFormatException("invalid data for y location: "
+                    throw new InvalidData("invalid data for y location: "
                         + yc.get("y").toString());
 
                 if (! yc.isSet("z"))
-                    throw new DataFormatException("missing z location");
+                    throw new InvalidData("missing z location");
                 if (! yc.isDouble("z"))
-                    throw new DataFormatException("invalid data for z location: "
+                    throw new InvalidData("invalid data for z location: "
                         + yc.get("z").toString());
 
                 if (! yc.isSet("yaw"))
-                    throw new DataFormatException("missing yaw");
+                    throw new InvalidData("missing yaw");
                 if (! yc.isDouble("yaw"))
-                    throw new DataFormatException("invalid data for yaw: "
+                    throw new InvalidData("invalid data for yaw: "
                         + yc.get("yaw").toString());
 
                 if (! yc.isSet("pitch"))
-                    throw new DataFormatException("missing pitch");
+                    throw new InvalidData("missing pitch");
                 if (! yc.isDouble("pitch"))
-                    throw new DataFormatException("invalid data for pitch: "
+                    throw new InvalidData("invalid data for pitch: "
                         + yc.get("pitch").toString());
 
                 MVDestination mydest = new ExactDestination();
@@ -140,7 +145,7 @@ public class MVPlayerLocation {
                     (float) yc.getDouble("yaw"), (float) yc.getDouble("pitch")));
                 return mydest;
 
-            } catch (DataFormatException e) {
+            } catch (InvalidData e) {
                 plugin.log(Level.SEVERE, "Failed to parse saved location of player '"
                     + player.getName() + "' (" + playerID + ") in world '" + world
                     + "': " + e.getMessage() + ".");

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerLocation.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVPlayerLocation.java
@@ -96,54 +96,48 @@ public class MVPlayerLocation {
             try {
                 if (! yc.isSet("schema"))
                     throw new DataFormatException("missing schema node");
-                Object schema = yc.get("schema");
-                if (! Integer.class.isInstance(schema))
+                if (! yc.isInt("schema"))
                     throw new DataFormatException("invalid schema version: "
-                        + schema.toString());
-                if ((Integer) schema != 1)
+                        + yc.get("schema").toString());
+                if (yc.getInt("schema") != 1)
                     throw new DataFormatException("invalid schema version: "
-                        + schema.toString());
+                        + yc.get("schema").toString());
 
                 if (! yc.isSet("x"))
                     throw new DataFormatException("missing x location");
-                Object x = yc.get("x");
-                if (! Double.class.isInstance(x))
+                if (! yc.isDouble("x"))
                     throw new DataFormatException("invalid data for x location: "
-                        + x.toString());
+                        + yc.get("x").toString());
 
                 if (! yc.isSet("y"))
                     throw new DataFormatException("missing y location");
-                Object y = yc.get("y");
-                if (! Double.class.isInstance(y))
+                if (! yc.isDouble("y"))
                     throw new DataFormatException("invalid data for y location: "
-                        + y.toString());
+                        + yc.get("y").toString());
 
                 if (! yc.isSet("z"))
                     throw new DataFormatException("missing z location");
-                Object z = yc.get("z");
-                if (! Double.class.isInstance(z))
+                if (! yc.isDouble("z"))
                     throw new DataFormatException("invalid data for z location: "
-                        + z.toString());
+                        + yc.get("z").toString());
 
                 if (! yc.isSet("yaw"))
                     throw new DataFormatException("missing yaw");
-                Object yaw = yc.get("yaw");
-                if (! Double.class.isInstance(yaw))
+                if (! yc.isDouble("yaw"))
                     throw new DataFormatException("invalid data for yaw: "
-                        + yaw.toString());
+                        + yc.get("yaw").toString());
 
                 if (! yc.isSet("pitch"))
                     throw new DataFormatException("missing pitch");
-                Object pitch = yc.get("pitch");
-                if (! Double.class.isInstance(pitch))
+                if (! yc.isDouble("pitch"))
                     throw new DataFormatException("invalid data for pitch: "
-                        + pitch.toString());
+                        + yc.get("pitch").toString());
 
                 MVDestination mydest = new ExactDestination();
                 ((ExactDestination) mydest).setDestination(new Location(
                     plugin.getMVWorldManager().getMVWorld(world).getCBWorld(),
-                    ((Double) x).doubleValue(), ((Double) y).doubleValue(), ((Double) z).doubleValue(),
-                    ((Double) yaw).floatValue(), ((Double) pitch).floatValue()));
+                    yc.getDouble("x"), yc.getDouble("y"), yc.getDouble("z"),
+                    (float) yc.getDouble("yaw"), (float) yc.getDouble("pitch")));
                 return mydest;
 
             } catch (DataFormatException e) {


### PR DESCRIPTION
First, thank you for the great plugin.  Recently I tested several plugins for managing multiple worlds and Multiverse-Core handily came out on top.  Thank you!

Secondly, this is not actually a request to merge code at this time--this code is definitely not ready to be merged.  I've submitted this PR more as an early request for comments and guidance as I work to get the code ready for a real pull request.  Will you please read through this submission and the accompanying code and provide any suggestions and guidance necessary for me to get this ready for a true pull request?

This code is intended to add a new, non-default feature to Multiverse-Core.  When enabled, the feature makes it so that when a player leaves a world, his/her last position in the world is saved.  Then, when teleporting back to the world using the teleport syntax of just the bare world name (i.e. no "w:" or "e:" prefix), the player is teleported to his/her previously saved location in the world rather than to the world's spawn point.  If the player has no saved location for the world, or if the save cannot be read/parsed for some reason, the player is teleported to the world's spawn point as a fallback measure.  The behavior when using the "w:" or "e:" syntaxes is unchanged (i.e. always teleports to the world's spawn location or an exact location, respectively).

In it's current form, the code works, but is in an hackish, "can I even get this to work" kind of state.  I need to take care of the following items before it's really ready for a true pull request:

1)  Currently, it's not possible to disable the feature.  I still need to add a configuration property for the plugin that will control whether the feature is enabled or disabled.  I plan to have it default to being disabled, so that, by default, there is no change in behavior.

2)  The code is currently embedded in several different classes.  Very ugly.  I need to refactor the code into it's own class(es) (and an exception) which will be utilized by the various listener and command classes.

3)  I haven't done anything about permissions, yet.  There should probably be separate permissions for teleporting to a world at the player's saved location versus teleporting to the world's spawn point or exact locations.

4)  The code currently saves a players location in a world when leaving a world either via teleporting or the player quitting.  It does not save players' locations when the server is stopped.  I'm not sure how to listen for that.  Is there a bukkit event?  A player's location is also not saved when he/she is kicked from a world.  I figure that if someone is misbehaving enough to be kicked, his/her location doesn't need to be save (however, if there was a previously saved location for the player, that saved information is not deleted).

5)  While my day job is software development, my experience is in other languages.  I've never written a line of Java until writing the code for this feature yesterday.  Hopefully, I haven't abused Java too badly, and there's likely more Java-like ways to do some of what this code does.  Suggestions are welcome, please.

One final note:  I have developed this code under Oracle's official Java 8 JDK.  Hopefully, I haven't used any constructs or patterns that cause problems on earlier versions or other flavors of Java.

Again, thank you for the great plugin.  I hope that I can get the code for this feature in order so that it can be merged.  Please let me know of any guidance and suggestions that you have.