### PR TITLE
Add ability to define coordinates in commands (set anchor and spawn)

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/commands/AnchorCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/AnchorCommand.java
@@ -9,6 +9,7 @@ package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permission;
@@ -25,7 +26,7 @@ public class AnchorCommand extends PaginatedCoreCommand<String> {
     public AnchorCommand(MultiverseCore plugin) {
         super(plugin);
         this.setName("Create, Delete and Manage Anchor Destinations.");
-        this.setCommandUsage("/mv anchor " + ChatColor.GREEN + "{name}" + ChatColor.GOLD + " [-d]");
+        this.setCommandUsage("/mv anchor " + ChatColor.GREEN + "{name}" + ChatColor.GOLD + " [-d] [WORLD:X,Y,Z[:PITCH[:YAW]]]");
         this.setArgRange(0, 2);
         this.addKey("mv anchor");
         this.addKey("mv anchors");
@@ -33,6 +34,9 @@ public class AnchorCommand extends PaginatedCoreCommand<String> {
         this.addKey("mvanchors");
         this.addCommandExample("/mv anchor " + ChatColor.GREEN + "awesomething");
         this.addCommandExample("/mv anchor " + ChatColor.GREEN + "otherthing");
+        this.addCommandExample("/mv anchor " + ChatColor.GREEN + "awesomething awesomeworld:23,42,-1337");
+        this.addCommandExample("/mv anchor " + ChatColor.GREEN + "awesomething awesomeworld:23,42,-1337:90");
+        this.addCommandExample("/mv anchor " + ChatColor.GREEN + "awesomething awesomeworld:23,42,-1337:90:0");
         this.addCommandExample("/mv anchor " + ChatColor.GREEN + "awesomething " + ChatColor.RED + "-d");
         this.addCommandExample("/mv anchors ");
         this.setPermission("multiverse.core.anchor.list", "Allows a player to list all anchors.", PermissionDefault.OP);
@@ -127,16 +131,24 @@ public class AnchorCommand extends PaginatedCoreCommand<String> {
             return;
         }
 
-        if (!(sender instanceof Player)) {
-            sender.sendMessage("You must be a player to create Anchors.");
-            return;
-        }
-
         if (!this.plugin.getMVPerms().hasPermission(sender, "multiverse.core.anchor.create", true)) {
             sender.sendMessage(ChatColor.RED + "You don't have the permission to create anchors!");
         } else {
-            Player player = (Player) sender;
-            if (this.plugin.getAnchorManager().saveAnchorLocation(args.get(0), player.getLocation())) {
+            Location target;
+            if (args.size() == 2) {
+                target = plugin.getLocationManipulation().stringToLocation(args.get(1));
+                if (target == null) {
+                    sender.sendMessage(ChatColor.RED + args.get(1) + ChatColor.WHITE + " is not a valid location! Location format is world:x,y,z[:pitch[:yaw]]");
+                    return;
+                }
+            } else if (sender instanceof Player) {
+                target = ((Player) sender).getLocation();
+            } else {
+                sender.sendMessage("Use /mv anchor {name} {world:x,y,z[:pitch[:yaw]]} to set the anchor from the console!");
+                return;
+            }
+
+            if (this.plugin.getAnchorManager().saveAnchorLocation(args.get(0), target)) {
                 sender.sendMessage("Anchor '" + args.get(0) + "' was successfully " + ChatColor.GREEN + "created!");
             } else {
                 sender.sendMessage("Anchor '" + args.get(0) + "' was " + ChatColor.RED + " NOT " + ChatColor.WHITE + "created!");

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ModifySetCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ModifySetCommand.java
@@ -51,7 +51,8 @@ public class ModifySetCommand extends MultiverseCommand {
         this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "heal " + ChatColor.RED + "true");
         this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "adjustspawn " + ChatColor.RED + "false");
         this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "spawn");
-        this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "spawn" + ChatColor.RED + "world:0,64,0:90:270");
+        this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "spawn" + ChatColor.RED + "e:world:0,64,0:90:270");
+        this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "spawn" + ChatColor.RED + "a:anchor");
         this.setPermission("multiverse.core.modify.set", "Modify various aspects of worlds. See the help wiki for how to use this command properly. "
                 + "If you do not include a world, the current world will be used.", PermissionDefault.OP);
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ModifySetCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ModifySetCommand.java
@@ -51,6 +51,7 @@ public class ModifySetCommand extends MultiverseCommand {
         this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "heal " + ChatColor.RED + "true");
         this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "adjustspawn " + ChatColor.RED + "false");
         this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "spawn");
+        this.addCommandExample("/mvm " + ChatColor.GOLD + "set " + ChatColor.GREEN + "spawn" + ChatColor.RED + "world:0,64,0:90:270");
         this.setPermission("multiverse.core.modify.set", "Modify various aspects of worlds. See the help wiki for how to use this command properly. "
                 + "If you do not include a world, the current world will be used.", PermissionDefault.OP);
     }
@@ -58,19 +59,9 @@ public class ModifySetCommand extends MultiverseCommand {
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
         // Special case for spawn:
-        if (args.size() == 1) {
-            if (!(sender instanceof Player)) {
-                sender.sendMessage("You must be a player to set the" + ChatColor.GREEN + " spawn");
-                return;
-            }
-            if (args.get(0).equalsIgnoreCase("spawn")) {
-                SetSpawnCommand c = new SetSpawnCommand(this.plugin);
-                c.setWorldSpawn(sender);
-
-            } else {
-                sender.sendMessage("Spawn is the only param with no" + ChatColor.GREEN + " VALUE");
-                sender.sendMessage("Type " + ChatColor.GREEN + "/mv modify ?" + ChatColor.WHITE + " For help.");
-            }
+        if (args.size() > 0 && args.get(0).equalsIgnoreCase("spawn")) {
+            SetSpawnCommand c = new SetSpawnCommand(this.plugin);
+            c.setWorldSpawn(sender, args.size() > 1 ? args.get(1) : null);
             return;
         }
         // We NEED a world from the command line

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/SetSpawnCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/SetSpawnCommand.java
@@ -26,54 +26,66 @@ public class SetSpawnCommand extends MultiverseCommand {
     public SetSpawnCommand(MultiverseCore plugin) {
         super(plugin);
         this.setName("Set World Spawn");
-        this.setCommandUsage("/mv setspawn");
-        this.setArgRange(0, 0);
+        this.setCommandUsage("/mv setspawn [WORLD:X,Y,Z[:PITCH[:YAW]]]");
+        this.setArgRange(0, 1);
         this.addKey("mvsetspawn");
         this.addKey("mvss");
         this.addKey("mv set spawn");
         this.addKey("mv setspawn");
         this.addKey("mvset spawn");
         this.addCommandExample("/mv set spawn");
+        this.addCommandExample("/mv set spawn world:0,64,0");
+        this.addCommandExample("/mv set spawn world:0,64,0:90");
+        this.addCommandExample("/mv set spawn world:0,64,0:90:270");
         this.setPermission("multiverse.core.spawn.set", "Sets the spawn for the current world.", PermissionDefault.OP);
     }
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        setWorldSpawn(sender);
+        setWorldSpawn(sender, args.size() > 0 ? args.get(0) : null);
     }
 
     /**
      * Does the actual spawn-setting-work.
      *
      * @param sender The {@link CommandSender} that's setting the spawn.
+     * @param locationString The location that the spawn should be set to as a string in fhte format world:x,y,z[:pitch[:yaw]].
+     *                       If the string is <tt>null</tt> if will use the sender's location if it is a player
      */
-    protected void setWorldSpawn(CommandSender sender) {
-        if (sender instanceof Player) {
-            Player p = (Player) sender;
-            Location l = p.getLocation();
-            World w = p.getWorld();
-            MultiverseWorld foundWorld = this.plugin.getMVWorldManager().getMVWorld(w.getName());
-            if (foundWorld != null) {
-                foundWorld.setSpawnLocation(p.getLocation());
-                BlockSafety bs = this.plugin.getBlockSafety();
-                if (!bs.playerCanSpawnHereSafely(p.getLocation()) && foundWorld.getAdjustSpawn()) {
-                    sender.sendMessage("It looks like that location would normally be unsafe. But I trust you.");
-                    sender.sendMessage("I'm turning off the Safe-T-Teleporter for spawns to this world.");
-                    sender.sendMessage("If you want this turned back on just do:");
-                    sender.sendMessage(ChatColor.AQUA + "/mvm set adjustspawn true " + foundWorld.getAlias());
-                    foundWorld.setAdjustSpawn(false);
-                }
-                sender.sendMessage("Spawn was set to: " + plugin.getLocationManipulation().strCoords(p.getLocation()));
-                if (!plugin.saveWorldConfig()) {
-                    sender.sendMessage(ChatColor.RED + "There was an issue saving worlds.yml!  Your changes will only be temporary!");
-                }
-            } else {
-                w.setSpawnLocation(l.getBlockX(), l.getBlockY(), l.getBlockZ());
-                sender.sendMessage("Multiverse does not know about this world, only X,Y and Z set. Please import it to set the spawn fully (Pitch/Yaws).");
+    protected void setWorldSpawn(CommandSender sender, String locationString) {
+        Location l;
+        if (locationString != null) {
+            l = plugin.getLocationManipulation().stringToLocation(locationString);
+            if (l == null) {
+                sender.sendMessage(ChatColor.RED + locationString + ChatColor.WHITE + " is not a valid location! Location format is world:x,y,z[:pitch[:yaw]]");
+                return;
             }
-
+        } else if (sender instanceof Player) {
+            l = ((Player) sender).getLocation();
         } else {
-            sender.sendMessage("You cannot use this command from the console.");
+            sender.sendMessage("Append the spawn location in the format world:x,y,z[:pitch[:yaw]] to set the spawn from the console!");
+            return;
+        }
+
+        World w = l.getWorld();
+        MultiverseWorld foundWorld = this.plugin.getMVWorldManager().getMVWorld(w.getName());
+        if (foundWorld != null) {
+            foundWorld.setSpawnLocation(l);
+            BlockSafety bs = this.plugin.getBlockSafety();
+            if (!bs.playerCanSpawnHereSafely(l) && foundWorld.getAdjustSpawn()) {
+                sender.sendMessage("It looks like that location would normally be unsafe. But I trust you.");
+                sender.sendMessage("I'm turning off the Safe-T-Teleporter for spawns to this world.");
+                sender.sendMessage("If you want this turned back on just do:");
+                sender.sendMessage(ChatColor.AQUA + "/mvm set adjustspawn true " + foundWorld.getAlias());
+                foundWorld.setAdjustSpawn(false);
+            }
+            sender.sendMessage("Spawn was set to: " + plugin.getLocationManipulation().strCoords(l));
+            if (!plugin.saveWorldConfig()) {
+                sender.sendMessage(ChatColor.RED + "There was an issue saving worlds.yml!  Your changes will only be temporary!");
+            }
+        } else {
+            w.setSpawnLocation(l.getBlockX(), l.getBlockY(), l.getBlockZ());
+            sender.sendMessage("Multiverse does not know about this world, only X,Y and Z set. Please import it to set the spawn fully (Pitch/Yaws).");
         }
     }
 }


### PR DESCRIPTION
This adds the ability to define the world spawn and anchors via the command and with that from the console or command blocks.

The location string uses the same format as the stored locations to not write code duplicate to the one already present in the SimpleLocationManipulation util. The resulting commands look like this:
`/mv anchor {anchorname} world:x,y,z[:pitch[:yaw]]`
`/mv setspawn world:x,y,z[:pitch[:yaw]]`
`/mv modify setspawn world:x,y,z[:pitch[:yaw]]`