### PR TITLE
Option to disable the automatic purge of entities

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MVWorld.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MVWorld.java
@@ -280,7 +280,9 @@ public class MVWorld implements MultiverseWorld {
                 }
                 world.setSpawnFlags(allowMonsters, allowAnimals);
             }
-            plugin.getMVWorldManager().getTheWorldPurger().purgeWorld(MVWorld.this);
+            if (MultiverseCoreConfiguration.getInstance().isAutoPurgeEnabled()) {
+                plugin.getMVWorldManager().getTheWorldPurger().purgeWorld(MVWorld.this);
+            }
             return super.validateChange(property, newValue, oldValue, object);
         }
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
@@ -67,6 +67,8 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     private volatile boolean defaultportalsearch;
     @Property
     private volatile int portalsearchradius;
+    @Property
+    private volatile boolean autopurge;
 
     public MultiverseCoreConfiguration() {
         super();
@@ -98,6 +100,7 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
         silentstart = false;
         defaultportalsearch = false;
         portalsearchradius = 128;
+        autopurge = true;
         // END CHECKSTYLE-SUPPRESSION: MagicNumberCheck
     }
 
@@ -331,5 +334,15 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Override
     public int getPortalSearchRadius() {
         return portalsearchradius;
+    }
+
+    @Override
+    public boolean isAutoPurgeEnabled() {
+        return autopurge;
+    }
+
+    @Override
+    public void setAutoPurgeEnabled(boolean autopurge) {
+        this.autopurge = autopurge;
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
@@ -199,4 +199,18 @@ public interface MultiverseCoreConfig extends ConfigurationSerializable {
      * @return The portal search radius.
      */
     int getPortalSearchRadius();
+
+    /**
+     * Gets whether or not the automatic purge of entities is enabled.
+     *
+     * @return True if automatic purge is enabled.
+     */
+    boolean isAutoPurgeEnabled();
+
+    /**
+     * Sets whether or not the automatic purge of entities is enabled.
+     *
+     * @param autopurge True if automatic purge should be enabled.
+     */
+    void setAutoPurgeEnabled(boolean autopurge);
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -10,6 +10,7 @@ package com.onarandombox.MultiverseCore.utils;
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.MVWorld;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.MultiverseCoreConfiguration;
 import com.onarandombox.MultiverseCore.WorldProperties;
 import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
@@ -474,7 +475,9 @@ public class WorldManager implements MVWorldManager {
             return false;
         }
         MVWorld world = new MVWorld(plugin, cbworld, mvworld);
-        this.worldPurger.purgeWorld(world);
+        if (MultiverseCoreConfiguration.getInstance().isAutoPurgeEnabled()) {
+            this.worldPurger.purgeWorld(world);
+        }
         this.worlds.put(worldName, world);
         return true;
     }


### PR DESCRIPTION
Sometimes you want mobs not to spawn from the minecraft mob spawning system but you do not want custom spawned mobs to be removed - this config option allows that.