### PR TITLE
Ensure anchors are saved in a machine-readable way

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/utils/SimpleLocationManipulation.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/SimpleLocationManipulation.java
@@ -19,6 +19,7 @@ import com.onarandombox.MultiverseCore.api.LocationManipulation;
 import java.text.DecimalFormat;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -52,7 +53,7 @@ public class SimpleLocationManipulation implements LocationManipulation {
         if (location == null) {
             return "";
         }
-        return String.format("%s:%.2f,%.2f,%.2f:%.2f:%.2f", location.getWorld().getName(),
+        return String.format(Locale.ENGLISH, "%s:%.2f,%.2f,%.2f:%.2f:%.2f", location.getWorld().getName(),
                 location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
     }
 


### PR DESCRIPTION
`locationToString()` is primarily used by the AnchorManager to persist
anchors to disk (the other use is for logging).

In a locale that uses periods as decimal separator, this works fine and
the anchors can be loaded when the server restarts.

However, in a locale that doesn't use periods (but commas, for instance)
this produces an `anchors.yml` that cannot be parsed when loaded.

Tying the string formatting in `locationToString()` to an English locale
makes it behave as expected, regardless of the external locale setting.

Fixes: #2102 