### PR TITLE
Update to 1.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,20 +14,17 @@
     <repositories>
       <!-- Spigot -->
         <repository>
-            <id>spigot-repo</id>
+            <id>spigotmc-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>onarandombox</id>
             <url>http://repo.onarandombox.com/content/groups/public</url>
         </repository>
+        <!-- Vault repository !-->
         <repository>
-            <id>spigot</id>
-            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
-        </repository>
-        <repository>
-            <id>vault-repo</id>
-            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
         <repository>
             <id>minebench-repo</id>
@@ -245,10 +242,10 @@
 
     <dependencies>
         <dependency>
-           <groupId>org.bukkit</groupId>
-           <artifactId>bukkit</artifactId>
-           <version>1.13.2-R0.1-SNAPSHOT</version>
-           <scope>provided</scope>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.15.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <!-- SerializationConfig Dependency -->
         <dependency>
@@ -265,7 +262,7 @@
         <!-- End of SerializationConfig Dependency -->
         <!-- Start of Economy Dependency -->
         <dependency>
-            <groupId>net.milkbowl.vault</groupId>
+            <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
             <scope>provided</scope>


### PR DESCRIPTION
Update dependencies to use 1.15.2, including updating the spigot dependency and Vault dependency.