### PR TITLE
Fix Travis Builds for Pull Requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ notifications:
   email: false
 before_install:
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
+dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,4 @@ jdk:
   - oraclejdk8
 notifications:
   email: false
-before_install:
-  - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 dist: trusty

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  java:
-    version: oraclejdk8


### PR DESCRIPTION
This should fix Travis Builds for Pull Requests. Currently, builds fail since Travis switched to Ubuntu Xenial where Oracle JDK 8 isn't available.

See https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365/2.