### PR TITLE
Fix NPE for invalid world argument in gamerule cmd

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/commands/GameruleCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/GameruleCommand.java
@@ -62,6 +62,11 @@ public class GameruleCommand extends MultiverseCommand {
             world = p.getWorld();
         } else {
             world = Bukkit.getWorld(args.get(2));
+            if (world == null) {
+                sender.sendMessage(ChatColor.RED + "Failure!" + ChatColor.WHITE + " World " + ChatColor.AQUA + args.get(2)
+                    + ChatColor.WHITE + " does not exist.");
+                return;
+            }
         }
 
         if (world.setGameRuleValue(gameRule, value)) {


### PR DESCRIPTION
Stumbled upon an NPE when using /mv gamerule. I realised it was because I had specified a nonexistent world. This simple PR should fix it.