### PR TITLE
Fixes alias not clearing after cloning the world

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -199,7 +199,7 @@ public class WorldManager implements MVWorldManager {
                 MVWorld newWorld = (MVWorld) this.getMVWorld(newName);
                 newWorld.copyValues(this.worldsFromTheConfig.get(oldName));
                 // don't keep the alias the same -- that would be useless
-                newWorld.setAlias(null);
+                newWorld.setAlias("");
                 return true;
             }
         }


### PR DESCRIPTION
This will rather set an alias to an empty string which will automatically be resulted in alias being as same as the name of the cloned world.
Previously, it was not working as intended and kept the alias of the oldWorld.