### PR TITLE
Remove Deprecated Portal Event

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -467,7 +467,6 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
         pm.registerEvents(this.entityListener, this);
         pm.registerEvents(this.weatherListener, this);
         pm.registerEvents(this.portalListener, this);
-        log(Level.INFO, "We are aware of the warning about the deprecated event. There is no alternative that allows us to do what we need to do. The performance impact is negligible.");
         pm.registerEvents(this.worldListener, this);
         pm.registerEvents(new MVMapListener(this), this);
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPortalListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPortalListener.java
@@ -14,7 +14,6 @@ import org.bukkit.PortalType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.entity.EntityCreatePortalEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.world.PortalCreateEvent;
 
@@ -32,28 +31,13 @@ public class MVPortalListener implements Listener {
     }
 
     /**
-     * This is called when an entity creates a portal.
+     * This is called when a portal is created.
      *
-     * @param event The event where an entity created a portal.
-     */
-    @EventHandler
-    public void entityPortalCreate(EntityCreatePortalEvent event) {
-        if (event.isCancelled() || event.getBlocks().size() == 0) {
-            return;
-        }
-        MultiverseWorld world = this.plugin.getMVWorldManager().getMVWorld(event.getEntity().getWorld());
-        // We have to do it like this due to a bug in 1.1-R3
-        if (world != null && !world.getAllowedPortals().isPortalAllowed(event.getPortalType())) {
-            event.setCancelled(true);
-        }
-    }
-
-    /**
-     * This is called when a portal is created as the result of another world being linked.
-     * @param event The event where a portal was formed due to a world link
+     * @param event The event where a portal is created.
      */
     @EventHandler(ignoreCancelled = true)
     public void portalForm(PortalCreateEvent event) {
+        // as of Bukkit 1.13, this event is only fired for nether portals
         MultiverseWorld world = this.plugin.getMVWorldManager().getMVWorld(event.getWorld());
         if (world != null && !world.getAllowedPortals().isPortalAllowed(PortalType.NETHER)) {
             plugin.log(Level.FINE, "Cancelling creation of nether portal because portalForm disallows.");


### PR DESCRIPTION
This PR removes the EntityCreatePortalEvent listener, thus closing #2000.

This does not affect the usage of portalForm, and was tested on 1.13.2, 1.14.4, 1.15.2.