### PR TITLE
Rework Webpaste Package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.number>UNKNOWN</project.build.number>
+        <project.bitly-access-token>bitly-access-token</project.bitly-access-token>
     </properties>
 
     <repositories>
@@ -69,6 +70,17 @@
                 <project.build.number>${env.BUILD_NUMBER}</project.build.number>
             </properties>
         </profile>
+        <profile>
+            <id>bitly</id>
+            <activation>
+                <property>
+                    <name>env.BITLY_ACCESS_TOKEN</name>
+                </property>
+            </activation>
+            <properties>
+                <project.bitly-access-token>${env.BITLY_ACCESS_TOKEN}</project.bitly-access-token>
+            </properties>
+        </profile>
     </profiles>
 
     <build>
@@ -90,21 +102,44 @@
                 <version>1.4.1</version>
                 <executions>
                     <execution>
+                        <id>replace-bitly-access-token</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <basedir>${project.build.sourceDirectory}</basedir>
+                            <includes>
+                                <include>com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java</include>
+                            </includes>
+                            <replacements>
+                                <replacement>
+                                    <token>bitly-access-token</token>
+                                    <value>${project.bitly-access-token}</value>
+                                </replacement>
+                            </replacements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>replace-maven-version-number</id>
                         <phase>prepare-package</phase>
                         <goals>
                             <goal>replace</goal>
                         </goals>
+                        <configuration>
+                            <basedir>${project.build.directory}/classes</basedir>
+                            <includes>
+                                <include>plugin.yml</include>
+                            </includes>
+                            <replacements>
+                                <replacement>
+                                    <token>maven-version-number</token>
+                                    <value>${project.version}-b${project.build.number}</value>
+                                </replacement>
+                            </replacements>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <file>target/classes/plugin.yml</file>
-                    <replacements>
-                        <replacement>
-                            <token>maven-version-number</token>
-                            <value>${project.version}-b${project.build.number}</value>
-                        </replacement>
-                    </replacements>
-                </configuration>
             </plugin>
             <!-- Jar Plugin -->
             <plugin>

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
@@ -24,9 +24,12 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.util.StringUtil;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,79 +53,74 @@ public class VersionCommand extends MultiverseCommand {
     }
 
     private String getLegacyString() {
-        StringBuilder legacyFile = new StringBuilder();
-        legacyFile.append("[Multiverse-Core] Multiverse-Core Version: ").append(this.plugin.getDescription().getVersion()).append('\n');
-        legacyFile.append("[Multiverse-Core] Bukkit Version: ").append(this.plugin.getServer().getVersion()).append('\n');
-        legacyFile.append("[Multiverse-Core] Loaded Worlds: ").append(this.plugin.getMVWorldManager().getMVWorlds()).append('\n');
-        legacyFile.append("[Multiverse-Core] Multiverse Plugins Loaded: ").append(this.plugin.getPluginCount()).append('\n');
-        legacyFile.append("[Multiverse-Core] Economy being used: ").append(plugin.getEconomist().getEconomyName()).append('\n');
-        legacyFile.append("[Multiverse-Core] Permissions Plugin: ").append(this.plugin.getMVPerms().getType()).append('\n');
-        legacyFile.append("[Multiverse-Core] Dumping Config Values: (version ")
-                .append(this.plugin.getMVConfig().getVersion()).append(")").append('\n');
-        legacyFile.append("[Multiverse-Core]  messagecooldown: ").append(plugin.getMessaging().getCooldown()).append('\n');
-        legacyFile.append("[Multiverse-Core]  teleportcooldown: ").append(plugin.getMVConfig().getTeleportCooldown()).append('\n');
-        legacyFile.append("[Multiverse-Core]  worldnameprefix: ").append(plugin.getMVConfig().getPrefixChat()).append('\n');
-        legacyFile.append("[Multiverse-Core]  worldnameprefixFormat: ").append(plugin.getMVConfig().getPrefixChatFormat()).append('\n');
-        legacyFile.append("[Multiverse-Core]  enforceaccess: ").append(plugin.getMVConfig().getEnforceAccess()).append('\n');
-        legacyFile.append("[Multiverse-Core]  displaypermerrors: ").append(plugin.getMVConfig().getDisplayPermErrors()).append('\n');
-        legacyFile.append("[Multiverse-Core]  teleportintercept: ").append(plugin.getMVConfig().getTeleportIntercept()).append('\n');
-        legacyFile.append("[Multiverse-Core]  firstspawnoverride: ").append(plugin.getMVConfig().getFirstSpawnOverride()).append('\n');
-        legacyFile.append("[Multiverse-Core]  firstspawnworld: ").append(plugin.getMVConfig().getFirstSpawnWorld()).append('\n');
-        legacyFile.append("[Multiverse-Core]  debug: ").append(plugin.getMVConfig().getGlobalDebug()).append('\n');
-        legacyFile.append("[Multiverse-Core] Special Code: FRN002").append('\n');
-        return legacyFile.toString();
+        return "[Multiverse-Core] Multiverse-Core Version: " + this.plugin.getDescription().getVersion() + System.lineSeparator() +
+                "[Multiverse-Core] Bukkit Version: " + this.plugin.getServer().getVersion() + System.lineSeparator() +
+                "[Multiverse-Core] Loaded Worlds: " + this.plugin.getMVWorldManager().getMVWorlds() + System.lineSeparator() +
+                "[Multiverse-Core] Multiverse Plugins Loaded: " + this.plugin.getPluginCount() + System.lineSeparator() +
+                "[Multiverse-Core] Economy being used: " + plugin.getEconomist().getEconomyName() + System.lineSeparator() +
+                "[Multiverse-Core] Permissions Plugin: " + this.plugin.getMVPerms().getType() + System.lineSeparator() +
+                "[Multiverse-Core] Dumping Config Values: (version " + this.plugin.getMVConfig().getVersion() + ")" + System.lineSeparator() +
+                "[Multiverse-Core]  messagecooldown: " + plugin.getMessaging().getCooldown() + System.lineSeparator() +
+                "[Multiverse-Core]  teleportcooldown: " + plugin.getMVConfig().getTeleportCooldown() + System.lineSeparator() +
+                "[Multiverse-Core]  worldnameprefix: " + plugin.getMVConfig().getPrefixChat() + System.lineSeparator() +
+                "[Multiverse-Core]  worldnameprefixFormat: " + plugin.getMVConfig().getPrefixChatFormat() + System.lineSeparator() +
+                "[Multiverse-Core]  enforceaccess: " + plugin.getMVConfig().getEnforceAccess() + System.lineSeparator() +
+                "[Multiverse-Core]  displaypermerrors: " + plugin.getMVConfig().getDisplayPermErrors() + System.lineSeparator() +
+                "[Multiverse-Core]  teleportintercept: " + plugin.getMVConfig().getTeleportIntercept() + System.lineSeparator() +
+                "[Multiverse-Core]  firstspawnoverride: " + plugin.getMVConfig().getFirstSpawnOverride() + System.lineSeparator() +
+                "[Multiverse-Core]  firstspawnworld: " + plugin.getMVConfig().getFirstSpawnWorld() + System.lineSeparator() +
+                "[Multiverse-Core]  debug: " + plugin.getMVConfig().getGlobalDebug() + System.lineSeparator() +
+                "[Multiverse-Core] Special Code: FRN002" + System.lineSeparator();
     }
 
     private String getMarkdownString() {
-        StringBuilder markdownString = new StringBuilder();
-        markdownString.append("# Multiverse-Core\n");
-        markdownString.append("## Overview\n");
-        markdownString.append("| Name | Value |\n");
-        markdownString.append("| --- | --- |\n");
-        markdownString.append("| Multiverse-Core Version | `").append(this.plugin.getDescription().getVersion()).append("` |\n");
-        markdownString.append("| Bukkit Version | `").append(this.plugin.getServer().getVersion()).append("` |\n");
-        //markdownString.append("| Loaded Worlds | `").append(this.plugin.getMVWorldManager().getMVWorlds()).append("` |\n");
-        markdownString.append("| Multiverse Plugins Loaded | `").append(this.plugin.getPluginCount()).append("` |\n");
-        markdownString.append("| Economy being used | `").append(plugin.getEconomist().getEconomyName()).append("` |\n");
-        markdownString.append("| Permissions Plugin | `").append(this.plugin.getMVPerms().getType()).append("` |\n");
-        markdownString.append("## Parsed Config\n");
-        markdownString.append("These are what Multiverse thought the in-memory values of the config were.\n\n");
-        markdownString.append("| Config Key  | Value |\n");
-        markdownString.append("| --- | --- |\n");
-        markdownString.append("| version | `").append(this.plugin.getMVConfig().getVersion()).append("` |\n");
-        markdownString.append("| messagecooldown | `").append(plugin.getMessaging().getCooldown()).append("` |\n");
-        markdownString.append("| teleportcooldown | `").append(plugin.getMVConfig().getTeleportCooldown()).append("` |\n");
-        markdownString.append("| worldnameprefix | `").append(plugin.getMVConfig().getPrefixChat()).append("` |\n");
-        markdownString.append("| worldnameprefixFormat | `").append(plugin.getMVConfig().getPrefixChatFormat()).append("` |\n");
-        markdownString.append("| enforceaccess | `").append(plugin.getMVConfig().getEnforceAccess()).append("` |\n");
-        markdownString.append("| displaypermerrors | `").append(plugin.getMVConfig().getDisplayPermErrors()).append("` |\n");
-        markdownString.append("| teleportintercept | `").append(plugin.getMVConfig().getTeleportIntercept()).append("` |\n");
-        markdownString.append("| firstspawnoverride | `").append(plugin.getMVConfig().getFirstSpawnOverride()).append("` |\n");
-        markdownString.append("| firstspawnworld | `").append(plugin.getMVConfig().getFirstSpawnWorld()).append("` |\n");
-        markdownString.append("| debug | `").append(plugin.getMVConfig().getGlobalDebug()).append("` |\n");
-        return markdownString.toString();
+        return "# Multiverse-Core" + System.lineSeparator() +
+                "## Overview" + System.lineSeparator() +
+                "| Name | Value |" + System.lineSeparator() +
+                "| --- | --- |" + System.lineSeparator() +
+                "| Multiverse-Core Version | `" + this.plugin.getDescription().getVersion() + "` |" + System.lineSeparator() +
+                "| Bukkit Version | `" + this.plugin.getServer().getVersion() + "` |" + System.lineSeparator() +
+                //"| Loaded Worlds | `" + this.plugin.getMVWorldManager().getMVWorlds() + "` |" + System.lineSeparator() +
+                "| Multiverse Plugins Loaded | `" + this.plugin.getPluginCount() + "` |" + System.lineSeparator() +
+                "| Economy being used | `" + plugin.getEconomist().getEconomyName() + "` |" + System.lineSeparator() +
+                "| Permissions Plugin | `" + this.plugin.getMVPerms().getType() + "` |" + System.lineSeparator() +
+                "## Parsed Config" + System.lineSeparator() +
+                "These are what Multiverse thought the in-memory values of the config were." + System.lineSeparator() + System.lineSeparator() +
+                "| Config Key  | Value |" + System.lineSeparator() +
+                "| --- | --- |" + System.lineSeparator() +
+                "| version | `" + this.plugin.getMVConfig().getVersion() + "` |" + System.lineSeparator() +
+                "| messagecooldown | `" + plugin.getMessaging().getCooldown() + "` |" + System.lineSeparator() +
+                "| teleportcooldown | `" + plugin.getMVConfig().getTeleportCooldown() + "` |" + System.lineSeparator() +
+                "| worldnameprefix | `" + plugin.getMVConfig().getPrefixChat() + "` |" + System.lineSeparator() +
+                "| worldnameprefixFormat | `" + plugin.getMVConfig().getPrefixChatFormat() + "` |" + System.lineSeparator() +
+                "| enforceaccess | `" + plugin.getMVConfig().getEnforceAccess() + "` |" + System.lineSeparator() +
+                "| displaypermerrors | `" + plugin.getMVConfig().getDisplayPermErrors() + "` |" + System.lineSeparator() +
+                "| teleportintercept | `" + plugin.getMVConfig().getTeleportIntercept() + "` |" + System.lineSeparator() +
+                "| firstspawnoverride | `" + plugin.getMVConfig().getFirstSpawnOverride() + "` |" + System.lineSeparator() +
+                "| firstspawnworld | `" + plugin.getMVConfig().getFirstSpawnWorld() + "` |" + System.lineSeparator() +
+                "| debug | `" + plugin.getMVConfig().getGlobalDebug() + "` |" + System.lineSeparator();
     }
 
     private String readFile(final String filename) {
-        String result;
+        StringBuilder result;
         try {
             FileReader reader = new FileReader(filename);
             BufferedReader bufferedReader = new BufferedReader(reader);
             String line;
-            result = "";
+            result = new StringBuilder();
             while ((line = bufferedReader.readLine()) != null) {
-                result += line + '\n';
+                result.append(line).append(System.lineSeparator());
             }
         } catch (FileNotFoundException e) {
             Logging.severe("Unable to find %s. Here's the traceback: %s", filename, e.getMessage());
             e.printStackTrace();
-            result = String.format("ERROR: Could not load: %s", filename);
+            result = new StringBuilder(String.format("ERROR: Could not load: %s", filename));
         } catch (IOException e) {
             Logging.severe("Something bad happend when reading %s. Here's the traceback: %s", filename, e.getMessage());
             e.printStackTrace();
-            result = String.format("ERROR: Could not load: %s", filename);
+            result = new StringBuilder(String.format("ERROR: Could not load: %s", filename));
         }
-        return result;
+        return result.toString();
     }
 
     private Map<String, String> getVersionFiles() {
@@ -155,13 +153,13 @@ public class VersionCommand extends MultiverseCommand {
         String versionInfo = versionEvent.getVersionInfo();
 
         if (CommandHandler.hasFlag("--include-plugin-list", args)) {
-            versionInfo = versionInfo + "\nPlugins: " + getPluginList();
+            versionInfo = versionInfo + System.lineSeparator() + "Plugins: " + getPluginList();
         }
 
         final String data = versionInfo;
 
         // log to console
-        String[] lines = data.split("\n");
+        String[] lines = data.split(System.lineSeparator());
         for (String line : lines) {
             if (!line.isEmpty()) {
                 Logging.info(line);
@@ -177,7 +175,7 @@ public class VersionCommand extends MultiverseCommand {
                         // private post to pastebin
                         pasteUrl = postToService(PasteServiceType.PASTEBIN, true, data, files);
                     } else if (CommandHandler.hasFlag("-h", args)) {
-                        // private post to pastebin
+                        // private post to hastebin
                         pasteUrl = postToService(PasteServiceType.HASTEBIN, true, data, files);
                     } else {
                         return;
@@ -216,8 +214,11 @@ public class VersionCommand extends MultiverseCommand {
             }
             return SHORTENER.shorten(result);
         } catch (PasteFailedException e) {
-            System.out.print(e);
-            return "Error posting to service";
+            e.printStackTrace();
+            return "Error posting to service.";
+        } catch (NullPointerException e) {
+            e.printStackTrace();
+            return "That service isn't supported yet.";
         }
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
@@ -81,7 +81,7 @@ public class VersionCommand extends MultiverseCommand {
                 "| --- | --- |" + System.lineSeparator() +
                 "| Multiverse-Core Version | `" + this.plugin.getDescription().getVersion() + "` |" + System.lineSeparator() +
                 "| Bukkit Version | `" + this.plugin.getServer().getVersion() + "` |" + System.lineSeparator() +
-                //"| Loaded Worlds | `" + this.plugin.getMVWorldManager().getMVWorlds() + "` |" + System.lineSeparator() +
+                "| Loaded Worlds | `" + this.plugin.getMVWorldManager().getMVWorlds() + "` |" + System.lineSeparator() +
                 "| Multiverse Plugins Loaded | `" + this.plugin.getPluginCount() + "` |" + System.lineSeparator() +
                 "| Economy being used | `" + plugin.getEconomist().getEconomyName() + "` |" + System.lineSeparator() +
                 "| Permissions Plugin | `" + this.plugin.getMVPerms().getType() + "` |" + System.lineSeparator() +
@@ -134,7 +134,7 @@ public class VersionCommand extends MultiverseCommand {
         File configFile = new File(this.plugin.getDataFolder(), "config.yml");
         files.put(configFile.getName(), this.readFile(configFile.getAbsolutePath()));
 
-        // Add the config.yml
+        // Add the worlds.yml
         File worldConfig = new File(this.plugin.getDataFolder(), "worlds.yml");
         files.put(worldConfig.getName(), this.readFile(worldConfig.getAbsolutePath()));
         return files;
@@ -148,13 +148,14 @@ public class VersionCommand extends MultiverseCommand {
         }
 
         MVVersionEvent versionEvent = new MVVersionEvent(this.getLegacyString(), this.getVersionFiles());
-        final Map<String, String> files = this.getVersionFiles();
         this.plugin.getServer().getPluginManager().callEvent(versionEvent);
 
         String versionInfo = versionEvent.getVersionInfo();
+        Map<String, String> files = versionEvent.getDetailedVersionInfo();
 
         if (CommandHandler.hasFlag("--include-plugin-list", args)) {
             versionInfo = versionInfo + System.lineSeparator() + "Plugins: " + getPluginList();
+            files.put("plugins.txt", "Plugins: " + getPluginList());
         }
 
         final String data = versionInfo;

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
@@ -49,7 +49,7 @@ public class VersionCommand extends MultiverseCommand {
         this.addKey("mvv");
         this.addKey("mvversion");
         this.setPermission("multiverse.core.version",
-                "Dumps version info to the console, optionally to pastie.org with -p or pastebin.com with a -b.", PermissionDefault.TRUE);
+                "Dumps version info to the console, optionally to pastebin.com with -b, or to hastebin.com using -h.", PermissionDefault.TRUE);
     }
 
     private String getLegacyString() {

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
@@ -44,13 +44,13 @@ public class VersionCommand extends MultiverseCommand {
     public VersionCommand(MultiverseCore plugin) {
         super(plugin);
         this.setName("Multiverse Version");
-        this.setCommandUsage("/mv version " + ChatColor.GOLD + "-[bh] [--include-plugin-list]");
+        this.setCommandUsage("/mv version " + ChatColor.GOLD + "-[bhp] [--include-plugin-list]");
         this.setArgRange(0, 2);
         this.addKey("mv version");
         this.addKey("mvv");
         this.addKey("mvversion");
         this.setPermission("multiverse.core.version",
-                "Dumps version info to the console, optionally to pastebin.com with -b, or to hastebin.com using -h.", PermissionDefault.TRUE);
+                "Dumps version info to the console, optionally to pastebin.com with -b, to hastebin.com using -h, or to paste.gg with -p.", PermissionDefault.TRUE);
     }
 
     private String getLegacyString() {
@@ -181,6 +181,9 @@ public class VersionCommand extends MultiverseCommand {
                     } else if (CommandHandler.hasFlag("-h", args)) {
                         // private post to hastebin
                         pasteUrl = postToService(PasteServiceType.HASTEBIN, true, data, files);
+                    } else if (CommandHandler.hasFlag("-p", args)) {
+                        // private post to paste.gg
+                        pasteUrl = postToService(PasteServiceType.PASTEGG, true, data, files);
                     } else {
                         return;
                     }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
@@ -174,7 +174,15 @@ public class VersionCommand extends MultiverseCommand {
                     if (CommandHandler.hasFlag("-b", args)) {
                         // private post to pastebin
                         pasteUrl = postToService(PasteServiceType.PASTEBIN, true, data, files);
-                    } else if (CommandHandler.hasFlag("-h", args)) {
+                    }
+
+                    // pasting to GitHub now requires an account, so we've disabled it
+                    /* else if (CommandHandler.hasFlag("-g", args)) {
+                        // private post to github
+                        pasteUrl = postToService(PasteServiceType.GITHUB, true, data, files);
+                    } */
+
+                    else if (CommandHandler.hasFlag("-h", args)) {
                         // private post to hastebin
                         pasteUrl = postToService(PasteServiceType.HASTEBIN, true, data, files);
                     } else {

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
@@ -60,16 +60,16 @@ public class VersionCommand extends MultiverseCommand {
                 "[Multiverse-Core] Economy being used: " + plugin.getEconomist().getEconomyName() + System.lineSeparator() +
                 "[Multiverse-Core] Permissions Plugin: " + this.plugin.getMVPerms().getType() + System.lineSeparator() +
                 "[Multiverse-Core] Dumping Config Values: (version " + this.plugin.getMVConfig().getVersion() + ")" + System.lineSeparator() +
-                "[Multiverse-Core]  messagecooldown: " + plugin.getMessaging().getCooldown() + System.lineSeparator() +
-                "[Multiverse-Core]  teleportcooldown: " + plugin.getMVConfig().getTeleportCooldown() + System.lineSeparator() +
-                "[Multiverse-Core]  worldnameprefix: " + plugin.getMVConfig().getPrefixChat() + System.lineSeparator() +
-                "[Multiverse-Core]  worldnameprefixFormat: " + plugin.getMVConfig().getPrefixChatFormat() + System.lineSeparator() +
-                "[Multiverse-Core]  enforceaccess: " + plugin.getMVConfig().getEnforceAccess() + System.lineSeparator() +
-                "[Multiverse-Core]  displaypermerrors: " + plugin.getMVConfig().getDisplayPermErrors() + System.lineSeparator() +
-                "[Multiverse-Core]  teleportintercept: " + plugin.getMVConfig().getTeleportIntercept() + System.lineSeparator() +
-                "[Multiverse-Core]  firstspawnoverride: " + plugin.getMVConfig().getFirstSpawnOverride() + System.lineSeparator() +
-                "[Multiverse-Core]  firstspawnworld: " + plugin.getMVConfig().getFirstSpawnWorld() + System.lineSeparator() +
-                "[Multiverse-Core]  debug: " + plugin.getMVConfig().getGlobalDebug() + System.lineSeparator() +
+                "[Multiverse-Core]   messagecooldown: " + plugin.getMessaging().getCooldown() + System.lineSeparator() +
+                "[Multiverse-Core]   teleportcooldown: " + plugin.getMVConfig().getTeleportCooldown() + System.lineSeparator() +
+                "[Multiverse-Core]   worldnameprefix: " + plugin.getMVConfig().getPrefixChat() + System.lineSeparator() +
+                "[Multiverse-Core]   worldnameprefixFormat: " + plugin.getMVConfig().getPrefixChatFormat() + System.lineSeparator() +
+                "[Multiverse-Core]   enforceaccess: " + plugin.getMVConfig().getEnforceAccess() + System.lineSeparator() +
+                "[Multiverse-Core]   displaypermerrors: " + plugin.getMVConfig().getDisplayPermErrors() + System.lineSeparator() +
+                "[Multiverse-Core]   teleportintercept: " + plugin.getMVConfig().getTeleportIntercept() + System.lineSeparator() +
+                "[Multiverse-Core]   firstspawnoverride: " + plugin.getMVConfig().getFirstSpawnOverride() + System.lineSeparator() +
+                "[Multiverse-Core]   firstspawnworld: " + plugin.getMVConfig().getFirstSpawnWorld() + System.lineSeparator() +
+                "[Multiverse-Core]   debug: " + plugin.getMVConfig().getGlobalDebug() + System.lineSeparator() +
                 "[Multiverse-Core] Special Code: FRN002" + System.lineSeparator();
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/event/MVVersionEvent.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/event/MVVersionEvent.java
@@ -66,4 +66,13 @@ public class MVVersionEvent extends Event {
     public void appendVersionInfo(String moreVersionInfo) {
         this.versionInfoBuilder.append(moreVersionInfo);
     }
+
+    /**
+     * Adds a file to to the detailed version-info currently saved in this event.
+     * @param filename The name of the file.
+     * @param text The file's content.
+     */
+    public void putDetailedVersionInfo(String filename, String text) {
+        this.detailedVersionInfo.put(filename, text);
+    }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
@@ -23,7 +23,7 @@ public class BitlyURLShortener extends HttpAPIClient implements URLShortener {
     public String shorten(String longUrl) {
         try {
             String result = this.exec(longUrl);
-            if (!result.startsWith("http://j.mp/")) // ... then it's failed :/
+            if (!result.startsWith("https://j.mp/")) // ... then it's failed :/
                 throw new IOException(result);
             return result;
         } catch (IOException e) {

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
@@ -8,13 +8,13 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * An {@link URLShortener} using {@code bit.ly}.
+ * A {@link URLShortener} using {@code bit.ly}. Requires an access token.
  */
 class BitlyURLShortener extends URLShortener {
     private static final String ACCESS_TOKEN = "Bearer bitly-access-token";
     private static final String BITLY_POST_REQUEST = "https://api-ssl.bitly.com/v4/shorten";
 
-    public BitlyURLShortener() {
+    BitlyURLShortener() {
         super(BITLY_POST_REQUEST, ACCESS_TOKEN);
         if (ACCESS_TOKEN.endsWith("access-token")) throw new UnsupportedOperationException();
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
@@ -1,19 +1,41 @@
 package com.onarandombox.MultiverseCore.utils.webpaste;
 
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * An {@link URLShortener} using {@code bit.ly}.
  */
-public class BitlyURLShortener extends HttpAPIClient implements URLShortener {
-    private static final String GENERIC_BITLY_REQUEST_FORMAT = "https://api-ssl.bitly.com/v3/shorten?format=txt&apiKey=%s&login=%s&longUrl=%s";
-
-    // I think it's no problem that these are public
-    private static final String USERNAME = "multiverse2";
-    private static final String API_KEY = "R_9dbff4862a3bc0c4218a7d78cc10d0e0";
+class BitlyURLShortener extends URLShortener {
+    private static final String ACCESS_TOKEN = "Bearer bitly-access-token";
+    private static final String BITLY_POST_REQUEST = "https://api-ssl.bitly.com/v4/shorten";
 
     public BitlyURLShortener() {
-        super(String.format(GENERIC_BITLY_REQUEST_FORMAT, API_KEY, USERNAME, "%s"));
+        super(BITLY_POST_REQUEST, ACCESS_TOKEN);
+        if (ACCESS_TOKEN.endsWith("access-token")) throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String encodeData(String data) {
+        JSONObject json = new JSONObject();
+        json.put("domain", "j.mp");
+        json.put("long_url", data);
+        return json.toJSONString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String encodeData(Map<String, String> data) {
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -22,13 +44,11 @@ public class BitlyURLShortener extends HttpAPIClient implements URLShortener {
     @Override
     public String shorten(String longUrl) {
         try {
-            String result = this.exec(longUrl);
-            if (!result.startsWith("https://j.mp/")) // ... then it's failed :/
-                throw new IOException(result);
-            return result;
-        } catch (IOException e) {
+            String stringJSON = this.exec(encodeData(longUrl), ContentType.JSON);
+            return (String) ((JSONObject) new JSONParser().parse(stringJSON)).get("link");
+        } catch (IOException | ParseException e) {
             e.printStackTrace();
-            return longUrl; // sorry ...
+            return longUrl;
         }
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
@@ -23,7 +23,7 @@ class BitlyURLShortener extends URLShortener {
      * {@inheritDoc}
      */
     @Override
-    protected String encodeData(String data) {
+    String encodeData(String data) {
         JSONObject json = new JSONObject();
         json.put("domain", "j.mp");
         json.put("long_url", data);
@@ -34,7 +34,7 @@ class BitlyURLShortener extends URLShortener {
      * {@inheritDoc}
      */
     @Override
-    protected String encodeData(Map<String, String> data) {
+    String encodeData(Map<String, String> data) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
@@ -11,6 +11,7 @@ import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,14 +65,18 @@ public class GithubPasteService implements PasteService {
         try {
             URLConnection conn = url.openConnection();
             conn.setDoOutput(true);
-            wr = new OutputStreamWriter(conn.getOutputStream());
+
+            // this isn't required, but is technically correct
+            conn.addRequestProperty("Content-Type", "application/json; charset=utf-8");
+
+            wr = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8);
             wr.write(encodedData);
             wr.flush();
 
-            rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             String line;
             StringBuilder responseString = new StringBuilder();
-
+            // this has to be initialized AFTER the data has been flushed!
+            rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
             while ((line = rd.readLine()) != null) {
                 responseString.append(line);
             }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
@@ -8,18 +8,24 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GitHubPasteService extends PasteService {
+/**
+ * Pastes to {@code gist.github.com}. Requires an access token with the {@code gist} scope.
+ */
+class GitHubPasteService extends PasteService {
     private final boolean isPrivate;
-    // this access token must have the "gist" OAuth scope
+    // this access token must have the "gist" scope
     private static final String ACCESS_TOKEN = "token github-access-token";
     private static final String GITHUB_POST_REQUEST = "https://api.github.com/gists";
 
-    public GitHubPasteService(boolean isPrivate) {
+    GitHubPasteService(boolean isPrivate) {
         super(GITHUB_POST_REQUEST, ACCESS_TOKEN);
         this.isPrivate = isPrivate;
         if (ACCESS_TOKEN.endsWith("access-token")) throw new UnsupportedOperationException();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     String encodeData(String data) {
         Map<String, String> mapData = new HashMap<String, String>();
@@ -27,6 +33,9 @@ public class GitHubPasteService extends PasteService {
         return this.encodeData(mapData);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     String encodeData(Map<String, String> files) {
         JSONObject root = new JSONObject();
@@ -43,6 +52,9 @@ public class GitHubPasteService extends PasteService {
         return root.toJSONString();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String postData(String data) throws PasteFailedException {
         try {
@@ -53,6 +65,9 @@ public class GitHubPasteService extends PasteService {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String postData(Map<String, String> data) throws PasteFailedException {
         try {
@@ -63,6 +78,9 @@ public class GitHubPasteService extends PasteService {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean supportsMultiFile() {
         return true;

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
@@ -1,26 +1,23 @@
 package com.onarandombox.MultiverseCore.utils.webpaste;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GitHubPasteService implements PasteService {
-
+public class GitHubPasteService extends PasteService {
     private final boolean isPrivate;
+    // this access token must have the "gist" OAuth scope
+    private static final String ACCESS_TOKEN = "token github-access-token";
+    private static final String GITHUB_POST_REQUEST = "https://api.github.com/gists";
 
     public GitHubPasteService(boolean isPrivate) {
+        super(GITHUB_POST_REQUEST, ACCESS_TOKEN);
         this.isPrivate = isPrivate;
+        if (ACCESS_TOKEN.endsWith("access-token")) throw new UnsupportedOperationException();
     }
 
     @Override
@@ -32,68 +29,37 @@ public class GitHubPasteService implements PasteService {
 
     @Override
     public String encodeData(Map<String, String> files) {
-        JsonObject root = new JsonObject();
-        root.add("description", new JsonPrimitive("Multiverse-Core Debug Info"));
-        root.add("public", new JsonPrimitive(!this.isPrivate));
-        JsonObject fileList = new JsonObject();
-        for (Map.Entry<String, String> entry : files.entrySet())
-        {
-            JsonObject fileObject = new JsonObject();
-            fileObject.add("content", new JsonPrimitive(entry.getValue()));
-            fileList.add(entry.getKey(), fileObject);
+        JSONObject root = new JSONObject();
+        root.put("description", "Multiverse-Core Debug Info");
+        root.put("public", !this.isPrivate);
+        JSONObject fileList = new JSONObject();
+        for (Map.Entry<String, String> entry : files.entrySet()) {
+            JSONObject fileObject = new JSONObject();
+            fileObject.put("content", entry.getValue());
+            fileList.put(entry.getKey(), fileObject);
         }
-        root.add("files", fileList);
-        return root.toString();
+
+        root.put("files", fileList);
+        return root.toJSONString();
     }
 
     @Override
-    public URL getPostURL() {
+    public String postData(String data) throws PasteFailedException {
         try {
-            return new URL("https://api.github.com/gists");
-
-            // the following can be used for testing purposes
-            // return new URL("http://jsonplaceholder.typicode.com/posts");
-        } catch (MalformedURLException e) {
-            return null; // should never hit here
-        }
-    }
-
-    @Override
-    public String postData(String encodedData, URL url) throws PasteFailedException {
-        OutputStreamWriter wr = null;
-        BufferedReader rd = null;
-        try {
-            URLConnection conn = url.openConnection();
-            conn.setDoOutput(true);
-
-            // this isn't required, but is technically correct
-            conn.addRequestProperty("Content-Type", "application/json; charset=utf-8");
-
-            wr = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8);
-            wr.write(encodedData);
-            wr.flush();
-
-            String line;
-            StringBuilder responseString = new StringBuilder();
-            // this has to be initialized AFTER the data has been flushed!
-            rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
-            while ((line = rd.readLine()) != null) {
-                responseString.append(line);
-            }
-            return new JsonParser().parse(responseString.toString()).getAsJsonObject().get("html_url").getAsString();
-        } catch (Exception e) {
+            String stringJSON = this.exec(encodeData(data), ContentType.JSON);
+            return (String) ((JSONObject) new JSONParser().parse(stringJSON)).get("html_url");
+        } catch (IOException | ParseException e) {
             throw new PasteFailedException(e);
-        } finally {
-            if (wr != null) {
-                try {
-                    wr.close();
-                } catch (IOException ignore) { }
-            }
-            if (rd != null) {
-                try {
-                    rd.close();
-                } catch (IOException ignore) { }
-            }
+        }
+    }
+
+    @Override
+    public String postData(Map<String, String> data) throws PasteFailedException {
+        try {
+            String stringJSON = this.exec(encodeData(data), ContentType.JSON);
+            return (String) ((JSONObject) new JSONParser().parse(stringJSON)).get("html_url");
+        } catch (IOException | ParseException e) {
+            throw new PasteFailedException(e);
         }
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
@@ -21,14 +21,14 @@ public class GitHubPasteService extends PasteService {
     }
 
     @Override
-    public String encodeData(String data) {
+    String encodeData(String data) {
         Map<String, String> mapData = new HashMap<String, String>();
         mapData.put("multiverse.txt", data);
         return this.encodeData(mapData);
     }
 
     @Override
-    public String encodeData(Map<String, String> files) {
+    String encodeData(Map<String, String> files) {
         JSONObject root = new JSONObject();
         root.put("description", "Multiverse-Core Debug Info");
         root.put("public", !this.isPrivate);

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GitHubPasteService.java
@@ -15,11 +15,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-public class GithubPasteService implements PasteService {
+public class GitHubPasteService implements PasteService {
 
     private final boolean isPrivate;
 
-    public GithubPasteService(boolean isPrivate) {
+    public GitHubPasteService(boolean isPrivate) {
         this.isPrivate = isPrivate;
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GithubPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/GithubPasteService.java
@@ -49,7 +49,9 @@ public class GithubPasteService implements PasteService {
     public URL getPostURL() {
         try {
             return new URL("https://api.github.com/gists");
-            //return new URL("http://jsonplaceholder.typicode.com/posts");
+
+            // the following can be used for testing purposes
+            // return new URL("http://jsonplaceholder.typicode.com/posts");
         } catch (MalformedURLException e) {
             return null; // should never hit here
         }
@@ -68,8 +70,6 @@ public class GithubPasteService implements PasteService {
 
             rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             String line;
-            String pastieUrl = "";
-            //Pattern pastiePattern = this.getURLMatchingPattern();
             StringBuilder responseString = new StringBuilder();
 
             while ((line = rd.readLine()) != null) {

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HastebinPasteService.java
@@ -1,6 +1,5 @@
 package com.onarandombox.MultiverseCore.utils.webpaste;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
 import java.io.BufferedReader;

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HastebinPasteService.java
@@ -9,6 +9,7 @@ import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -43,14 +44,19 @@ public class HastebinPasteService implements PasteService {
             URLConnection conn = url.openConnection();
             conn.setDoOutput(true);
 
-            wr = new OutputStreamWriter(conn.getOutputStream());
-            rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            // hastebin needs a user-agent
+            conn.addRequestProperty("User-Agent", "placeholder");
+            // this isn't required, but is technically correct
+            conn.addRequestProperty("Content-Type", "text/plain; charset=utf-8");
 
+            wr = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8.newEncoder());
             wr.write(encodedData);
             wr.flush();
 
             String line;
             StringBuilder responseString = new StringBuilder();
+            // this has to be initialized AFTER the data has been flushed!
+            rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
             while ((line = rd.readLine()) != null) {
                 responseString.append(line);
             }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HastebinPasteService.java
@@ -13,7 +13,7 @@ import java.util.Map;
 class HastebinPasteService extends PasteService {
     private static final String HASTEBIN_POST_REQUEST = "https://hastebin.com/documents";
 
-    public HastebinPasteService() {
+    HastebinPasteService() {
         super(HASTEBIN_POST_REQUEST, null);
     }
 
@@ -33,6 +33,9 @@ class HastebinPasteService extends PasteService {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String postData(String data) throws PasteFailedException {
         try {
@@ -43,6 +46,9 @@ class HastebinPasteService extends PasteService {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String postData(Map<String, String> data) throws PasteFailedException {
         try {
@@ -53,6 +59,9 @@ class HastebinPasteService extends PasteService {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean supportsMultiFile() {
         return false;

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HastebinPasteService.java
@@ -21,7 +21,7 @@ class HastebinPasteService extends PasteService {
      * {@inheritDoc}
      */
     @Override
-    public String encodeData(String data) {
+    String encodeData(String data) {
         return data;
     }
 
@@ -29,7 +29,7 @@ class HastebinPasteService extends PasteService {
      * {@inheritDoc}
      */
     @Override
-    public String encodeData(Map<String, String> data) {
+    String encodeData(Map<String, String> data) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HttpAPIClient.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HttpAPIClient.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 
 /**
  * HTTP API-client.
@@ -32,11 +33,11 @@ public abstract class HttpAPIClient {
         StringBuilder ret = new StringBuilder();
         BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
             while (!reader.ready()); // wait until reader is ready, may not be necessary, SUPPRESS CHECKSTYLE: EmptyStatement
 
             while (reader.ready()) {
-                ret.append(reader.readLine()).append('\n');
+                ret.append(reader.readLine()).append(System.lineSeparator());
             }
         } finally {
             if (reader != null) {

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HttpAPIClient.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HttpAPIClient.java
@@ -12,7 +12,7 @@ import java.util.Map;
 /**
  * HTTP API-client.
  */
-public abstract class HttpAPIClient {
+abstract class HttpAPIClient {
     /**
      * The URL for this API-request, and if necessary, the access token.
      * If an access token is not necessary, it should be set to null.
@@ -29,11 +29,16 @@ public abstract class HttpAPIClient {
         URLENCODED
     }
 
-    public HttpAPIClient(String url, String accessToken) {
+    HttpAPIClient(String url, String accessToken) {
         this.url = url;
         this.accessToken = accessToken;
     }
 
+    /**
+     * Returns the HTTP Content-Type header that corresponds with each ContentType.
+     * @param type The type of data.
+     * @return The HTTP Content-Type header that corresponds with the type of data.
+     */
     private String getContentHeader(ContentType type) {
         switch (type) {
             case JSON:

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HttpAPIClient.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HttpAPIClient.java
@@ -23,7 +23,7 @@ public abstract class HttpAPIClient {
     /**
      * Types of data that can be sent.
      */
-    protected enum ContentType {
+    enum ContentType {
         JSON,
         PLAINTEXT,
         URLENCODED
@@ -53,7 +53,7 @@ public abstract class HttpAPIClient {
      * @param data The raw data to encode.
      * @return A URL-encoded string.
      */
-    protected abstract String encodeData(String data);
+    abstract String encodeData(String data);
 
     /**
      * Encode the given Map data into a format suitable for transmission in an HTTP request.
@@ -61,7 +61,7 @@ public abstract class HttpAPIClient {
      * @param data The raw data to encode.
      * @return A URL-encoded string.
      */
-    protected abstract String encodeData(Map<String, String> data);
+    abstract String encodeData(Map<String, String> data);
 
     /**
      * Executes this API-Request.
@@ -70,7 +70,7 @@ public abstract class HttpAPIClient {
      * @return The result (as text).
      * @throws IOException When the I/O-operation failed.
      */
-    protected final String exec(String payload, ContentType type) throws IOException {
+    final String exec(String payload, ContentType type) throws IOException {
         BufferedReader rd = null;
         OutputStreamWriter wr = null;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HttpAPIClient.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/HttpAPIClient.java
@@ -1,51 +1,115 @@
 package com.onarandombox.MultiverseCore.utils.webpaste;
 
+import javax.net.ssl.HttpsURLConnection;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 /**
  * HTTP API-client.
  */
 public abstract class HttpAPIClient {
     /**
-     * The URL for this API-request.
+     * The URL for this API-request, and if necessary, the access token.
+     * If an access token is not necessary, it should be set to null.
      */
-    protected final String urlFormat;
+    private final String url;
+    private final String accessToken;
 
-    public HttpAPIClient(String urlFormat) {
-        this.urlFormat = urlFormat;
+    /**
+     * Types of data that can be sent.
+     */
+    protected enum ContentType {
+        JSON,
+        PLAINTEXT,
+        URLENCODED
+    }
+
+    public HttpAPIClient(String url, String accessToken) {
+        this.url = url;
+        this.accessToken = accessToken;
+    }
+
+    private String getContentHeader(ContentType type) {
+        switch (type) {
+            case JSON:
+                return "application/json; charset=utf-8";
+            case PLAINTEXT:
+                return "text/plain; charset=utf-8";
+            case URLENCODED:
+                return "application/x-www-form-urlencoded; charset=utf-8";
+            default:
+                throw new IllegalStateException("Unexpected value: " + type);
+        }
     }
 
     /**
+     * Encode the given String data into a format suitable for transmission in an HTTP request.
+     *
+     * @param data The raw data to encode.
+     * @return A URL-encoded string.
+     */
+    protected abstract String encodeData(String data);
+
+    /**
+     * Encode the given Map data into a format suitable for transmission in an HTTP request.
+     *
+     * @param data The raw data to encode.
+     * @return A URL-encoded string.
+     */
+    protected abstract String encodeData(Map<String, String> data);
+
+    /**
      * Executes this API-Request.
-     * @param args Format-args.
+     * @param payload The data that will be sent.
+     * @param type The type of data that will be sent.
      * @return The result (as text).
      * @throws IOException When the I/O-operation failed.
      */
-    protected final String exec(Object... args) throws IOException {
+    protected final String exec(String payload, ContentType type) throws IOException {
+        BufferedReader rd = null;
+        OutputStreamWriter wr = null;
 
-        URLConnection conn = new URL(String.format(this.urlFormat, args)).openConnection();
-        conn.connect();
-        StringBuilder ret = new StringBuilder();
-        BufferedReader reader = null;
         try {
-            reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
-            while (!reader.ready()); // wait until reader is ready, may not be necessary, SUPPRESS CHECKSTYLE: EmptyStatement
+            HttpsURLConnection conn = (HttpsURLConnection) new URL(this.url).openConnection();
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
 
-            while (reader.ready()) {
-                ret.append(reader.readLine()).append(System.lineSeparator());
-            }
+            // we can receive anything!
+            conn.addRequestProperty("Accept", "*/*");
+            // set a dummy User-Agent
+            conn.addRequestProperty("User-Agent", "placeholder");
+            // this isn't required, but is technically correct
+            conn.addRequestProperty("Content-Type", getContentHeader(type));
+            // only some API requests require an access token
+            if (this.accessToken != null) conn.addRequestProperty("Authorization", this.accessToken);
+
+            wr = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8.newEncoder());
+            wr.write(payload);
+            wr.flush();
+
+            String line;
+            StringBuilder responseString = new StringBuilder();
+            // this has to be initialized AFTER the data has been flushed!
+            rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
+
+            while ((line = rd.readLine()) != null) responseString.append(line);
+            return responseString.toString();
         } finally {
-            if (reader != null) {
+            if (wr != null) {
                 try {
-                    reader.close();
+                    wr.close();
+                } catch (IOException ignore) { }
+            }
+            if (rd != null) {
+                try {
+                    rd.close();
                 } catch (IOException ignore) { }
             }
         }
-        return ret.toString();
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteFailedException.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteFailedException.java
@@ -1,7 +1,7 @@
 package com.onarandombox.MultiverseCore.utils.webpaste;
 
 /**
- * Thrown when pasting failed.
+ * Thrown when pasting fails.
  */
 public class PasteFailedException extends Exception {
     public PasteFailedException() {

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteGGPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteGGPasteService.java
@@ -1,0 +1,90 @@
+package com.onarandombox.MultiverseCore.utils.webpaste;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Pastes to {@code paste.gg}.
+ */
+class PasteGGPasteService extends PasteService {
+    private final boolean isPrivate;
+    private static final String PASTEGG_POST_REQUEST = "https://api.paste.gg/v1/pastes";
+
+    PasteGGPasteService(boolean isPrivate) {
+        super(PASTEGG_POST_REQUEST, null);
+        this.isPrivate = isPrivate;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    String encodeData(String data) {
+        Map<String, String> mapData = new HashMap<String, String>();
+        mapData.put("multiverse.txt", data);
+        return this.encodeData(mapData);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    String encodeData(Map<String, String> files) {
+        JSONObject root = new JSONObject();
+        root.put("name", "Multiverse-Core Debug Info");
+        root.put("visibility", this.isPrivate ? "unlisted" : "public");
+        JSONArray fileList = new JSONArray();
+        for (Map.Entry<String, String> entry : files.entrySet()) {
+            JSONObject fileObject = new JSONObject();
+            JSONObject contentObject = new JSONObject();
+            fileObject.put("name", entry.getKey());
+            fileObject.put("content", contentObject);
+            contentObject.put("format", "text");
+            contentObject.put("value", entry.getValue());
+            fileList.add(fileObject);
+        }
+
+        root.put("files", fileList);
+        return root.toJSONString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String postData(String data) throws PasteFailedException {
+        try {
+            String stringJSON = this.exec(encodeData(data), ContentType.JSON);
+            return (String) ((JSONObject) ((JSONObject) new JSONParser().parse(stringJSON)).get("result")).get("id");
+        } catch (IOException | ParseException e) {
+            throw new PasteFailedException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String postData(Map<String, String> data) throws PasteFailedException {
+        try {
+            String stringJSON = this.exec(encodeData(data), ContentType.JSON);
+            return "https://paste.gg/" + ((JSONObject) ((JSONObject) new JSONParser().parse(stringJSON)).get("result")).get("id");
+        } catch (IOException | ParseException e) {
+            throw new PasteFailedException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean supportsMultiFile() {
+        return true;
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteService.java
@@ -1,6 +1,5 @@
 package com.onarandombox.MultiverseCore.utils.webpaste;
 
-import java.net.URL;
 import java.util.Map;
 
 /**
@@ -15,41 +14,30 @@ import java.util.Map;
  * should implement a custom constructor that specifies which kind the PasteService
  * instance is submitting; an example of this is the PastebinPasteService class.
  */
-public interface PasteService {
+public abstract class PasteService extends HttpAPIClient {
+    public PasteService(String url, String accessToken) {
+        super(url, accessToken);
+    }
 
     /**
-     * Encode the given String data into a format suitable for transmission in an HTTP request.
+     * Post data to the Web.
      *
-     * @param data The raw data to encode.
-     * @return A URL-encoded string.
-     */
-    String encodeData(String data);
-
-    /**
-     * Encode the given Map data into a format suitable for transmission in an HTTP request.
-     *
-     * @param data The raw data to encode.
-     * @return A URL-encoded string.
-     */
-    String encodeData(Map<String, String> data);
-
-    /**
-     * Get the URL to which this paste service sends new pastes.
-     *
-     * @return The URL that will be accessed to complete the paste.
-     */
-    URL getPostURL();
-
-    /**
-     * Post encoded data to the Web.
-     *
-     * @param encodedData A URL-encoded String containing the full request to post to
-     *                    the given URL. Can be the result of calling #encodeData().
-     * @param url The URL to which to paste. Can be the result of calling #getPostURL().
+     * @param data A URL-encoded String containing the full request to post to
+     *             the given URL. Can be the result of calling #encodeData().
      * @throws PasteFailedException When pasting/posting the data failed.
      * @return The URL at which the new paste is visible.
      */
-    String postData(String encodedData, URL url) throws PasteFailedException;
+    public abstract String postData(String data) throws PasteFailedException;
+
+    /**
+     * Post data to the Web.
+     *
+     * @param data A URL-encoded Map containing the full request to post to
+     *             the given URL. Can be the result of calling #encodeData().
+     * @throws PasteFailedException When pasting/posting the data failed.
+     * @return The URL at which the new paste is visible.
+     */
+    public abstract String postData(Map<String, String> data) throws PasteFailedException;
 
     /**
      * Does this service support uploading multiple files.
@@ -59,5 +47,5 @@ public interface PasteService {
      *
      * @return True if this service supports multiple file upload.
      */
-    boolean supportsMultiFile();
+    public abstract boolean supportsMultiFile();
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteService.java
@@ -3,27 +3,25 @@ package com.onarandombox.MultiverseCore.utils.webpaste;
 import java.util.Map;
 
 /**
- * An interface to a web-based text-pasting service. Classes implementing this
- * interface should implement its methods to send data to an online text-sharing
- * service, such as pastebin.com. Conventionally, a paste is accomplished by (given
- * some PasteService instance ps):
+ * An interface to a web-based text-pasting service. Classes extending this
+ * should implement its methods to send data to an online text-sharing service,
+ * such as pastebin.com. Given some PasteService instance ps, a paste is accomplished by:
  *
- * {@code ps.postData(ps.encodeData(someString), ps.getPostURL());}
+ * {@code ps.postData(someString);}
  *
  * Services that provide a distinction between "public" and "private" pastes
- * should implement a custom constructor that specifies which kind the PasteService
+ * should implement a constructor that specifies which kind the PasteService
  * instance is submitting; an example of this is the PastebinPasteService class.
  */
 public abstract class PasteService extends HttpAPIClient {
-    public PasteService(String url, String accessToken) {
+    PasteService(String url, String accessToken) {
         super(url, accessToken);
     }
 
     /**
      * Post data to the Web.
      *
-     * @param data A URL-encoded String containing the full request to post to
-     *             the given URL. Can be the result of calling #encodeData().
+     * @param data A String to post to the web.
      * @throws PasteFailedException When pasting/posting the data failed.
      * @return The URL at which the new paste is visible.
      */
@@ -32,8 +30,7 @@ public abstract class PasteService extends HttpAPIClient {
     /**
      * Post data to the Web.
      *
-     * @param data A URL-encoded Map containing the full request to post to
-     *             the given URL. Can be the result of calling #encodeData().
+     * @param data A Map to post to the web.
      * @throws PasteFailedException When pasting/posting the data failed.
      * @return The URL at which the new paste is visible.
      */
@@ -42,8 +39,8 @@ public abstract class PasteService extends HttpAPIClient {
     /**
      * Does this service support uploading multiple files.
      *
-     * Newer services like gist support multi-file which allows us to upload configs
-     * in addition to the standard logs.
+     * Newer services like GitHub's Gist support multi-file pastes,
+     * which allows us to upload configs in addition to the standard logs.
      *
      * @return True if this service supports multiple file upload.
      */

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteServiceFactory.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteServiceFactory.java
@@ -14,6 +14,8 @@ public class PasteServiceFactory {
      */
     public static PasteService getService(PasteServiceType type, boolean isPrivate) {
         switch(type) {
+            case PASTEGG:
+                return new PasteGGPasteService(isPrivate);
             case PASTEBIN:
                 return new PastebinPasteService(isPrivate);
             case HASTEBIN:

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteServiceFactory.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteServiceFactory.java
@@ -19,7 +19,7 @@ public class PasteServiceFactory {
             case HASTEBIN:
                 return new HastebinPasteService();
             case GITHUB:
-                return new GithubPasteService(isPrivate);
+                return new GitHubPasteService(isPrivate);
             default:
                 return null;
         }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteServiceType.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteServiceType.java
@@ -8,6 +8,10 @@ package com.onarandombox.MultiverseCore.utils.webpaste;
  */
 public enum PasteServiceType {
     /**
+     * @see PasteGGPasteService
+     */
+    PASTEGG,
+    /**
      * @see PastebinPasteService
      */
     PASTEBIN,

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteServiceType.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PasteServiceType.java
@@ -16,7 +16,7 @@ public enum PasteServiceType {
      */
     HASTEBIN,
     /**
-     * @see GithubPasteService
+     * @see GitHubPasteService
      */
     GITHUB
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
@@ -12,7 +12,7 @@ class PastebinPasteService extends PasteService {
     private final boolean isPrivate;
     private static final String PASTEBIN_POST_REQUEST = "https://pastebin.com/api/api_post.php";
 
-    public PastebinPasteService(boolean isPrivate) {
+    PastebinPasteService(boolean isPrivate) {
         super(PASTEBIN_POST_REQUEST, null);
         this.isPrivate = isPrivate;
     }
@@ -66,6 +66,9 @@ class PastebinPasteService extends PasteService {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean supportsMultiFile() {
         return false;

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
@@ -40,12 +40,11 @@ public class PastebinPasteService implements PasteService {
     @Override
     public String encodeData(String data) {
         try {
-            String encData = URLEncoder.encode("api_dev_key", "UTF-8") + "=" + URLEncoder.encode("d61d68d31e8e0392b59b50b277411c71", "UTF-8");
-            encData += "&" + URLEncoder.encode("api_option", "UTF-8") + "=" + URLEncoder.encode("paste", "UTF-8");
-            encData += "&" + URLEncoder.encode("api_paste_code", "UTF-8") + "=" + URLEncoder.encode(data, "UTF-8");
-            encData += "&" + URLEncoder.encode("api_paste_private", "UTF-8") + "=" + URLEncoder.encode(this.isPrivate ? "1" : "0", "UTF-8");
-            encData += "&" + URLEncoder.encode("api_paste_format", "UTF-8") + "=" + URLEncoder.encode("yaml", "UTF-8");
-            return encData;
+            return URLEncoder.encode("api_dev_key", "UTF-8") + "=" + URLEncoder.encode("d61d68d31e8e0392b59b50b277411c71", "UTF-8") +
+            "&" + URLEncoder.encode("api_option", "UTF-8") + "=" + URLEncoder.encode("paste", "UTF-8") +
+            "&" + URLEncoder.encode("api_paste_code", "UTF-8") + "=" + URLEncoder.encode(data, "UTF-8") +
+            "&" + URLEncoder.encode("api_paste_private", "UTF-8") + "=" + URLEncoder.encode(this.isPrivate ? "1" : "0", "UTF-8") +
+            "&" + URLEncoder.encode("api_paste_format", "UTF-8") + "=" + URLEncoder.encode("yaml", "UTF-8");
         } catch (UnsupportedEncodingException e) {
             return ""; // should never hit here
         }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
@@ -9,6 +9,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -65,13 +66,18 @@ public class PastebinPasteService implements PasteService {
         try {
             URLConnection conn = url.openConnection();
             conn.setDoOutput(true);
-            wr = new OutputStreamWriter(conn.getOutputStream());
+
+            // this isn't required, but is technically correct
+            conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
+
+            wr = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8);
             wr.write(encodedData);
             wr.flush();
 
-            rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             String line;
             String pastebinUrl = "";
+            // this has to be initialized AFTER the data has been flushed!
+            rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
             while ((line = rd.readLine()) != null) {
                 pastebinUrl = line;
             }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
@@ -1,38 +1,20 @@
 package com.onarandombox.MultiverseCore.utils.webpaste;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
  * Pastes to {@code pastebin.com}.
  */
-public class PastebinPasteService implements PasteService {
-
-    private boolean isPrivate;
+class PastebinPasteService extends PasteService {
+    private final boolean isPrivate;
+    private static final String PASTEBIN_POST_REQUEST = "https://pastebin.com/api/api_post.php";
 
     public PastebinPasteService(boolean isPrivate) {
+        super(PASTEBIN_POST_REQUEST, null);
         this.isPrivate = isPrivate;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public URL getPostURL() {
-        try {
-            return new URL("http://pastebin.com/api/api_post.php");
-        } catch (MalformedURLException e) {
-            return null; // should never hit here
-        }
     }
 
     /**
@@ -42,59 +24,45 @@ public class PastebinPasteService implements PasteService {
     public String encodeData(String data) {
         try {
             return URLEncoder.encode("api_dev_key", "UTF-8") + "=" + URLEncoder.encode("d61d68d31e8e0392b59b50b277411c71", "UTF-8") +
-            "&" + URLEncoder.encode("api_option", "UTF-8") + "=" + URLEncoder.encode("paste", "UTF-8") +
-            "&" + URLEncoder.encode("api_paste_code", "UTF-8") + "=" + URLEncoder.encode(data, "UTF-8") +
-            "&" + URLEncoder.encode("api_paste_private", "UTF-8") + "=" + URLEncoder.encode(this.isPrivate ? "1" : "0", "UTF-8") +
-            "&" + URLEncoder.encode("api_paste_format", "UTF-8") + "=" + URLEncoder.encode("yaml", "UTF-8");
+                    "&" + URLEncoder.encode("api_option", "UTF-8") + "=" + URLEncoder.encode("paste", "UTF-8") +
+                    "&" + URLEncoder.encode("api_paste_code", "UTF-8") + "=" + URLEncoder.encode(data, "UTF-8") +
+                    "&" + URLEncoder.encode("api_paste_private", "UTF-8") + "=" + URLEncoder.encode(this.isPrivate ? "1" : "0", "UTF-8") +
+                    "&" + URLEncoder.encode("api_paste_format", "UTF-8") + "=" + URLEncoder.encode("yaml", "UTF-8") +
+                    "&" + URLEncoder.encode("api_paste_name", "UTF-8") + "=" + URLEncoder.encode("Multiverse-Core Debug Info", "UTF-8");
         } catch (UnsupportedEncodingException e) {
             return ""; // should never hit here
         }
-    }
-
-    @Override
-    public String encodeData(Map<String, String> data) {
-        return null;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public String postData(String encodedData, URL url) throws PasteFailedException {
-        OutputStreamWriter wr = null;
-        BufferedReader rd = null;
+    public String encodeData(Map<String, String> data) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String postData(String data) throws PasteFailedException {
         try {
-            URLConnection conn = url.openConnection();
-            conn.setDoOutput(true);
-
-            // this isn't required, but is technically correct
-            conn.addRequestProperty("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
-
-            wr = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8);
-            wr.write(encodedData);
-            wr.flush();
-
-            String line;
-            String pastebinUrl = "";
-            // this has to be initialized AFTER the data has been flushed!
-            rd = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
-            while ((line = rd.readLine()) != null) {
-                pastebinUrl = line;
-            }
-            return pastebinUrl;
-        } catch (Exception e) {
+            return this.exec(encodeData(data), ContentType.URLENCODED);
+        } catch (IOException e) {
             throw new PasteFailedException(e);
-        } finally {
-            if (wr != null) {
-                try {
-                    wr.close();
-                } catch (IOException ignore) { }
-            }
-            if (rd != null) {
-                try {
-                    rd.close();
-                } catch (IOException ignore) { }
-            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String postData(Map<String, String> data) throws PasteFailedException {
+        try {
+            return this.exec(encodeData(data), ContentType.URLENCODED);
+        } catch (IOException e) {
+            throw new PasteFailedException(e);
         }
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/PastebinPasteService.java
@@ -21,7 +21,7 @@ class PastebinPasteService extends PasteService {
      * {@inheritDoc}
      */
     @Override
-    public String encodeData(String data) {
+    String encodeData(String data) {
         try {
             return URLEncoder.encode("api_dev_key", "UTF-8") + "=" + URLEncoder.encode("d61d68d31e8e0392b59b50b277411c71", "UTF-8") +
                     "&" + URLEncoder.encode("api_option", "UTF-8") + "=" + URLEncoder.encode("paste", "UTF-8") +
@@ -38,7 +38,7 @@ class PastebinPasteService extends PasteService {
      * {@inheritDoc}
      */
     @Override
-    public String encodeData(Map<String, String> data) {
+    String encodeData(Map<String, String> data) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/URLShortener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/URLShortener.java
@@ -3,11 +3,15 @@ package com.onarandombox.MultiverseCore.utils.webpaste;
 /**
  * URL-Shortener.
  */
-public interface URLShortener {
+public abstract class URLShortener extends HttpAPIClient {
+    public URLShortener(String url, String accessToken) {
+        super(url, accessToken);
+    }
+
     /**
-     * Shorten an URL.
+     * Shorten a URL.
      * @param longUrl The long form.
      * @return The shortened URL.
      */
-    String shorten(String longUrl);
+    public abstract String shorten(String longUrl);
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/URLShortener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/URLShortener.java
@@ -1,10 +1,16 @@
 package com.onarandombox.MultiverseCore.utils.webpaste;
 
 /**
- * URL-Shortener.
+ * An interface to a web-based URL Shortener. Classes extending this should
+ * implement its methods to shorten links using the service. Given some
+ * URLShortener instance us, a URL is shortened by:
+ *
+ * {@code us.shorten(longUrl);}
+ *
+ * An example of this, is the BitlyURLShortener.
  */
 public abstract class URLShortener extends HttpAPIClient {
-    public URLShortener(String url, String accessToken) {
+    URLShortener(String url, String accessToken) {
         super(url, accessToken);
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/URLShortenerFactory.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/URLShortenerFactory.java
@@ -1,0 +1,23 @@
+package com.onarandombox.MultiverseCore.utils.webpaste;
+
+/**
+ * Used to construct {@link URLShortener}s.
+ */
+public class URLShortenerFactory {
+    private URLShortenerFactory() { }
+
+    /**
+     * Constructs a new {@link URLShortener}.
+     * @param type The {@link URLShortenerType}.
+     * @return The newly created {@link URLShortener}.
+     */
+    public static URLShortener getService(URLShortenerType type) {
+        if (type == URLShortenerType.BITLY) {
+            try {
+                return new BitlyURLShortener();
+            } catch (UnsupportedOperationException ignored) {}
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/URLShortenerType.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/URLShortenerType.java
@@ -1,0 +1,14 @@
+package com.onarandombox.MultiverseCore.utils.webpaste;
+
+/**
+ * An enum containing all known {@link URLShortener}s.
+ *
+ * @see URLShortener
+ * @see URLShortenerFactory
+ */
+public enum URLShortenerType {
+    /**
+     * @see BitlyURLShortener
+     */
+    BITLY
+}


### PR DESCRIPTION
This is all the commits from #2279 pertaining to the webpaste package.

This PR fixes #2278 and #2277. It adds support for pasting to [paste.gg](paste.gg), and reworks the class hierarchy to make it easier to add new services. Additionally, support for services that require auth tokens has been simplified.

The one additional commit this PR has over #2279 is 55a9d10. Which brings multi-file pastes to parity with the older single-file pastes. I'll open a PR for the other MV plugins to support this.