### PR TITLE
Don't Report Generator Settings

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/utils/metrics/MetricsConfigurator.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/metrics/MetricsConfigurator.java
@@ -61,7 +61,7 @@ public class MetricsConfigurator {
 
     private String getGeneratorName(MultiverseWorld world) {
         String gen = world.getGenerator();
-        return (gen != null && !gen.equalsIgnoreCase("null")) ? gen : NO_GENERATOR_NAME;
+        return (gen != null && !gen.equalsIgnoreCase("null")) ? gen.split(":")[0] : NO_GENERATOR_NAME;
     }
 
     private void addEnvironmentsMetric() {


### PR DESCRIPTION
The way our Custom Generator Metric works right now makes it hard to read the results.

This changes it so that it only reports the name of the generator, and not its settings. This could be changed to a drilldown pie chart, but I don't think that there will be any meaningful data in the drilldown.