### PR TITLE
Fix Double Prefix when Logging Version Info

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
@@ -149,7 +149,7 @@ public class VersionCommand extends MultiverseCommand {
         String[] lines = versionInfo.split(System.lineSeparator());
         for (String line : lines) {
             if (!line.isEmpty()) {
-                Logging.info(line);
+                this.plugin.getServer().getLogger().info(line);
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue where two prefixes are logged when dumping the version info.