### PR TITLE
Refractor targetWorld for multiverse commands

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/commands/GameruleCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/GameruleCommand.java
@@ -8,12 +8,11 @@
 package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
-import org.bukkit.Bukkit;
+import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import org.bukkit.ChatColor;
 import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionDefault;
 
 import java.util.List;
@@ -40,35 +39,14 @@ public class GameruleCommand extends MultiverseCommand {
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        // We NEED a world from the command line
-        final Player p;
-        if (sender instanceof Player) {
-            p = (Player) sender;
-        } else {
-            p = null;
-        }
-
-        if (args.size() == 2 && p == null) {
-            sender.sendMessage("From the command line, WORLD is required.");
-            sender.sendMessage(this.getCommandDesc());
-            sender.sendMessage(this.getCommandUsage());
-            sender.sendMessage("Nothing changed.");
+        MultiverseWorld world = getTargetWorld(sender, args, 2);
+        if (world == null) {
             return;
         }
 
+        final World CBWorld = world.getCBWorld();
         final GameRule gameRule = GameRule.getByName(args.get(0));
         final String value = args.get(1);
-        final World world;
-        if (args.size() == 2) {
-            world = p.getWorld();
-        } else {
-            world = Bukkit.getWorld(args.get(2));
-            if (world == null) {
-                sender.sendMessage(ChatColor.RED + "Failure!" + ChatColor.WHITE + " World " + ChatColor.AQUA + args.get(2)
-                        + ChatColor.WHITE + " does not exist.");
-                return;
-            }
-        }
 
         if (gameRule == null) {
             sender.sendMessage(ChatColor.RED + "Failure! " + ChatColor.AQUA + args.get(0) + ChatColor.WHITE
@@ -85,13 +63,13 @@ public class GameruleCommand extends MultiverseCommand {
                     return;
                 }
 
-                if (!world.setGameRule(gameRule, booleanValue)) {
+                if (!CBWorld.setGameRule(gameRule, booleanValue)) {
                     sender.sendMessage(getErrorMessage(gameRule.getName(), value) + "something went wrong.");
                     return;
                 }
             } else if (gameRule.getType() == Integer.class) {
                 try {
-                    if (!world.setGameRule(gameRule, Integer.parseInt(value))) {
+                    if (!CBWorld.setGameRule(gameRule, Integer.parseInt(value))) {
                         throw new NumberFormatException();
                     }
                 } catch (NumberFormatException e) {

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/GamerulesCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/GamerulesCommand.java
@@ -8,12 +8,11 @@
 package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
-import org.bukkit.Bukkit;
+import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import org.bukkit.ChatColor;
 import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionDefault;
 
 import java.util.List;
@@ -40,41 +39,19 @@ public class GamerulesCommand extends MultiverseCommand {
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        // We NEED a world from the command line
-        final Player p;
-        if (sender instanceof Player) {
-            p = (Player) sender;
-        } else {
-            p = null;
-        }
-
-        if (args.size() == 0 && p == null) {
-            sender.sendMessage("From the command line, WORLD is required.");
-            sender.sendMessage(this.getCommandDesc());
-            sender.sendMessage(this.getCommandUsage());
-            sender.sendMessage("Nothing changed.");
+        MultiverseWorld world = getTargetWorld(sender, args, 0);
+        if (world == null) {
             return;
         }
 
-        final World world;
-        if (args.size() == 0) {
-            world = p.getWorld();
-        } else {
-            world = Bukkit.getWorld(args.get(0));
-            if (world == null) {
-                sender.sendMessage(ChatColor.RED + "Failure!" + ChatColor.WHITE + " World " + ChatColor.AQUA + args.get(0)
-                        + ChatColor.WHITE + " does not exist.");
-                return;
-            }
-        }
-
+        final World CBWorld = world.getCBWorld();
         final StringBuilder gameRules = new StringBuilder();
-        for (final String gameRule : world.getGameRules()) {
+        for (final String gameRule : CBWorld.getGameRules()) {
             if (gameRules.length() != 0) {
                 gameRules.append(ChatColor.WHITE).append(", ");
             }
             gameRules.append(ChatColor.AQUA).append(gameRule).append(ChatColor.WHITE).append(": ");
-            gameRules.append(ChatColor.GREEN).append(world.getGameRuleValue(GameRule.getByName(gameRule)));
+            gameRules.append(ChatColor.GREEN).append(CBWorld.getGameRuleValue(GameRule.getByName(gameRule)));
         }
         sender.sendMessage("=== Gamerules for " + ChatColor.AQUA + world.getName() + ChatColor.WHITE + " ===");
         sender.sendMessage(gameRules.toString());

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ModifyAddCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ModifyAddCommand.java
@@ -8,12 +8,10 @@
 package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
-import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.enums.Action;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionDefault;
 
 import java.util.List;
@@ -25,7 +23,6 @@ import java.util.List;
  * Used to modify various aspects of worlds.
  */
 public class ModifyAddCommand extends MultiverseCommand {
-    private MVWorldManager worldManager;
 
     public ModifyAddCommand(MultiverseCore plugin) {
         super(plugin);
@@ -41,39 +38,16 @@ public class ModifyAddCommand extends MultiverseCommand {
         this.addCommandExample("/mvm " + ChatColor.GOLD + "add " + ChatColor.GREEN + "MyWorld " + ChatColor.RED + "worldblacklist");
         this.setPermission("multiverse.core.modify.add", "Modify various aspects of worlds. See the help wiki for how to use this command properly. "
                 + "If you do not include a world, the current world will be used.", PermissionDefault.OP);
-        this.worldManager = this.plugin.getMVWorldManager();
     }
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        // We NEED a world from the command line
-        Player p = null;
-        if (sender instanceof Player) {
-            p = (Player) sender;
-        }
-
-        if (args.size() == 2 && p == null) {
-            sender.sendMessage(ChatColor.RED + "From the console, WORLD is required.");
-            sender.sendMessage(this.getCommandDesc());
-            sender.sendMessage(this.getCommandUsage());
-            sender.sendMessage("Nothing changed.");
-            return;
-        }
-
-        MultiverseWorld world;
-        String value = args.get(0);
-        String property = args.get(1);
-
-        if (args.size() == 2) {
-            world = this.worldManager.getMVWorld(p.getWorld().getName());
-        } else {
-            world = this.worldManager.getMVWorld(args.get(2));
-        }
-
+        MultiverseWorld world = getTargetWorld(sender, args, 2);
         if (world == null) {
-            sender.sendMessage("That world does not exist!");
             return;
         }
+        String property = args.get(0);
+        String value = args.get(1);
 
         if (!ModifyCommand.validateAction(Action.Add, property)) {
             sender.sendMessage("Sorry, you can't ADD to " + property);

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ModifyClearCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ModifyClearCommand.java
@@ -8,12 +8,10 @@
 package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
-import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.enums.Action;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionDefault;
 
 import java.util.List;
@@ -22,7 +20,6 @@ import java.util.List;
  * Removes all values from a world-property.
  */
 public class ModifyClearCommand extends MultiverseCommand {
-    private MVWorldManager worldManager;
 
     public ModifyClearCommand(MultiverseCore plugin) {
         super(plugin);
@@ -38,37 +35,15 @@ public class ModifyClearCommand extends MultiverseCommand {
         this.addCommandExample("/mvm " + ChatColor.GOLD + "clear " + ChatColor.RED + "worldblacklist");
         this.setPermission("multiverse.core.modify.clear",
                 "Removes all values from a property. This will work on properties that contain lists.", PermissionDefault.OP);
-        this.worldManager = this.plugin.getMVWorldManager();
     }
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        // We NEED a world from the command line
-        Player p = null;
-        if (sender instanceof Player) {
-            p = (Player) sender;
-        }
-        if (args.size() == 1 && p == null) {
-            sender.sendMessage(ChatColor.RED + "From the console, WORLD is required.");
-            sender.sendMessage(this.getCommandDesc());
-            sender.sendMessage(this.getCommandUsage());
-            sender.sendMessage("Nothing changed.");
-            return;
-        }
-
-        MultiverseWorld world;
-        String property = args.get(0);
-
-        if (args.size() == 1) {
-            world = this.worldManager.getMVWorld(p.getWorld().getName());
-        } else {
-            world = this.worldManager.getMVWorld(args.get(1));
-        }
-
+        MultiverseWorld world = getTargetWorld(sender, args, 1);
         if (world == null) {
-            sender.sendMessage("That world does not exist!");
             return;
         }
+        String property = args.get(0);
 
         if (!ModifyCommand.validateAction(Action.Clear, property)) {
             sender.sendMessage("Sorry, you can't use CLEAR with " + property);

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ModifyRemoveCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ModifyRemoveCommand.java
@@ -8,12 +8,10 @@
 package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
-import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.enums.Action;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionDefault;
 
 import java.util.List;
@@ -22,7 +20,6 @@ import java.util.List;
  * Removes values from a world-property.
  */
 public class ModifyRemoveCommand extends MultiverseCommand {
-    private MVWorldManager worldManager;
 
     public ModifyRemoveCommand(MultiverseCore plugin) {
         super(plugin);
@@ -42,39 +39,16 @@ public class ModifyRemoveCommand extends MultiverseCommand {
         this.addCommandExample("/mvm " + ChatColor.GOLD + "remove " + ChatColor.GREEN + "MyWorld " + ChatColor.RED + "worldblacklist");
         this.setPermission("multiverse.core.modify.remove", "Modify various aspects of worlds. See the help wiki for how to use this command properly. "
                 + "If you do not include a world, the current world will be used.", PermissionDefault.OP);
-        this.worldManager = this.plugin.getMVWorldManager();
     }
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        // We NEED a world from the command line
-        Player p = null;
-        if (sender instanceof Player) {
-            p = (Player) sender;
-        }
-
-        if (args.size() == 2 && p == null) {
-            sender.sendMessage(ChatColor.RED + "From the console, WORLD is required.");
-            sender.sendMessage(this.getCommandDesc());
-            sender.sendMessage(this.getCommandUsage());
-            sender.sendMessage("Nothing changed.");
-            return;
-        }
-
-        MultiverseWorld world;
-        String value = args.get(0);
-        String property = args.get(1);
-
-        if (args.size() == 2) {
-            world = this.worldManager.getMVWorld(p.getWorld().getName());
-        } else {
-            world = this.worldManager.getMVWorld(args.get(2));
-        }
-
+        MultiverseWorld world = getTargetWorld(sender, args, 2);
         if (world == null) {
-            sender.sendMessage("That world does not exist!");
             return;
         }
+        String property = args.get(0);
+        String value = args.get(1);
 
         if (!ModifyCommand.validateAction(Action.Remove, property)) {
             sender.sendMessage("Sorry, you can't REMOVE anything from" + property);

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ModifySetCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ModifySetCommand.java
@@ -8,7 +8,6 @@
 package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
-import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.enums.EnglishChatColor;
 import com.onarandombox.MultiverseCore.exceptions.PropertyDoesNotExistException;
@@ -23,11 +22,9 @@ import java.util.List;
  * Used to set world-properties.
  */
 public class ModifySetCommand extends MultiverseCommand {
-    private MVWorldManager worldManager;
 
     public ModifySetCommand(MultiverseCore plugin) {
         super(plugin);
-        this.worldManager = this.plugin.getMVWorldManager();
         this.setName("Modify a World (Set a value)");
         this.setCommandUsage("/mv modify" + ChatColor.GREEN + " set {PROPERTY} {VALUE}" + ChatColor.GOLD + " [WORLD]");
         this.setArgRange(1, 3);
@@ -73,34 +70,13 @@ public class ModifySetCommand extends MultiverseCommand {
             }
             return;
         }
-        // We NEED a world from the command line
-        Player p = null;
-        if (sender instanceof Player) {
-            p = (Player) sender;
-        }
 
-        if (args.size() == 2 && p == null) {
-            sender.sendMessage("From the command line, WORLD is required.");
-            sender.sendMessage(this.getCommandDesc());
-            sender.sendMessage(this.getCommandUsage());
-            sender.sendMessage("Nothing changed.");
-            return;
-        }
-
-        MultiverseWorld world;
-        String value = args.get(1);
-        String property = args.get(0);
-
-        if (args.size() == 2) {
-            world = this.worldManager.getMVWorld(p.getWorld().getName());
-        } else {
-            world = this.worldManager.getMVWorld(args.get(2));
-        }
-
+        MultiverseWorld world = getTargetWorld(sender, args, 2);
         if (world == null) {
-            sender.sendMessage("That world does not exist!");
             return;
         }
+        String property = args.get(0);
+        String value = args.get(1);
 
         if ((property.equalsIgnoreCase("aliascolor") || property.equalsIgnoreCase("color")) && !EnglishChatColor.isValidAliasColor(value)) {
             sender.sendMessage(value + " is not a valid color. Please pick one of the following:");

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/MultiverseCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/MultiverseCommand.java
@@ -9,8 +9,11 @@ package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MultiverseMessaging;
+import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.pneumaticraft.commandhandler.Command;
+import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import java.util.List;
 
@@ -32,6 +35,50 @@ public abstract class MultiverseCommand extends Command {
         super(plugin);
         this.plugin = plugin;
         this.messaging = this.plugin.getMessaging();
+    }
+
+    /**
+     * Get world that sender is in.
+     *
+     * @param sender   The object executing the command.
+     * @return Returns {@link MultiverseWorld} sender is in if sender is a player, else returns null.
+     */
+    protected MultiverseWorld getSenderWorld(CommandSender sender) {
+        if (sender instanceof Player) {
+            return this.plugin.getMVWorldManager().getMVWorld(((Player) sender).getWorld().getName());
+        }
+        return null;
+    }
+
+    /**
+     * Get world based on sender and args.
+     *
+     * @param sender         The object executing the command.
+     * @param args           The arguments of the command.
+     * @param argWorldIndex  Index of args where the worldName is.
+     * @return Returns {@link MultiverseWorld} if target world is found, else return null.
+     */
+    protected MultiverseWorld getTargetWorld(CommandSender sender, List<String> args, int argWorldIndex) {
+        MultiverseWorld world;
+
+        if (args.size() <= argWorldIndex) {
+            world = getSenderWorld(sender);
+            if (world == null) {
+                sender.sendMessage(ChatColor.RED + "From the command line, WORLD is required.");
+                sender.sendMessage(this.getCommandDesc());
+                sender.sendMessage(this.getCommandUsage());
+                sender.sendMessage("Nothing changed.");
+            }
+            return world;
+        }
+
+        String targetWorld = args.get(argWorldIndex);
+        world = this.plugin.getMVWorldManager().getMVWorld(targetWorld);
+        if (world == null) {
+            sender.sendMessage(ChatColor.RED + "Failure!" + ChatColor.WHITE + " World '" + ChatColor.AQUA + targetWorld
+                    + ChatColor.WHITE + "' does not exist.");
+        }
+        return world;
     }
 
     @Override


### PR DESCRIPTION
While doing PR #2446 I realised there was quite a lot of copied code for the modify add, clear, remove and set commands, so just refractor it and generalise it to ModifyCommand#getTargetWorld method.

EDIT: I changed it be in MultiverseCommand class so it can be used in other commands such as `/mv gamerule` and `/mv gamerules`