### PR TITLE
Adds ability to set fixed player join location.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -317,7 +317,12 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
         } catch (NullPointerException e) {
             // A test that had no worlds loaded was being run. This should never happen in production
         }
+
+        // Now set the joinlocation (after the worlds are loaded):
+        this.worldManager.setJoinLocation(getMVConfig().getJoinLocation());
+
         this.saveMVConfig();
+
         // Register async or sync player chat according to config
         try {
             Class.forName("org.bukkit.event.player.AsyncPlayerChatEvent");

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
@@ -66,6 +66,10 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Property
     private volatile String firstspawnworld;
     @Property
+    private volatile boolean joinlocationoverride;
+    @Property
+    private volatile String joinlocation;
+    @Property
     private volatile int teleportcooldown;
     @Property
     private volatile boolean defaultportalsearch;
@@ -108,6 +112,8 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
         portalsearchradius = 128;
         autopurge = true;
         idonotwanttodonate = false;
+        joinlocationoverride = false;
+        joinlocation = "";
         // END CHECKSTYLE-SUPPRESSION: MagicNumberCheck
     }
 
@@ -362,5 +368,25 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Override
     public void setShowDonateMessage(boolean showDonateMessage) {
         this.idonotwanttodonate = !showDonateMessage;
+    }
+
+    @Override
+    public boolean getJoinLocationOverride() {
+        return this.joinlocationoverride;
+    }
+
+    @Override
+    public void setJoinLocationOverride(boolean joinLocationOverride) {
+        this.joinlocationoverride = joinLocationOverride;
+    }
+
+    @Override
+    public String getJoinLocation() {
+        return this.joinlocation;
+    }
+
+    @Override
+    public void setJoinLocation(String joinLocation) {
+        this.joinlocation = joinLocation;
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
@@ -9,10 +9,12 @@ package com.onarandombox.MultiverseCore.api;
 
 import com.onarandombox.MultiverseCore.utils.PurgeWorlds;
 import com.onarandombox.MultiverseCore.utils.SimpleWorldPurger;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.WorldType;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.generator.ChunkGenerator;
 
 import java.io.File;
@@ -288,6 +290,21 @@ public interface MVWorldManager {
      * @return The {@link MultiverseWorld} new players should spawn in.
      */
     MultiverseWorld getFirstSpawnWorld();
+
+    /**
+     * Sets location where the player should spawn on join.
+     *
+     * @param destination The target destination based on {@link com.onarandombox.MultiverseCore.destination.DestinationFactory}
+     */
+    void setJoinLocation(String destination);
+
+    /**
+     * Gets preset location where the player should spawn on join.
+     *
+     * @param player The target {@link Player} for the {@link MVDestination}.
+     * @return The preset {@link Location} players should spawn in pm join.
+     */
+    Location getJoinLocation(Player player);
 
     /**
      * Regenerates a world.

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
@@ -227,4 +227,12 @@ public interface MultiverseCoreConfig extends ConfigurationSerializable {
      * @param idonotwanttodonate True if donation/patreon messages should be shown.
      */
     void setShowDonateMessage(boolean idonotwanttodonate);
+
+    boolean getJoinLocationOverride();
+
+    void setJoinLocationOverride(boolean joinLocationOverride);
+
+    String getJoinLocation();
+
+    void setJoinLocation(String joinLocation);
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ConfigCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ConfigCommand.java
@@ -61,6 +61,10 @@ public class ConfigCommand extends MultiverseCommand {
             // Don't forget to set the world!
             this.plugin.getMVWorldManager().setFirstSpawnWorld(args.get(1));
         }
+        if (args.get(0).equalsIgnoreCase("joinlocation")) {
+            // Don't forget to set the location!
+            this.plugin.getMVWorldManager().setJoinLocation(args.get(1));
+        }
 
         if (this.plugin.saveMVConfigs()) {
             sender.sendMessage(ChatColor.GREEN + "SUCCESS!" + ChatColor.WHITE + " Values were updated successfully!");

--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
@@ -123,6 +123,11 @@ public class MVPlayerListener implements Listener {
                     && !this.plugin.getMVPerms().hasPermission(p, "multiverse.access." + p.getWorld().getName(), false)) {
                 p.sendMessage("[MV] - Sorry you can't be in this world anymore!");
                 this.sendPlayerToDefaultWorld(p);
+                return;
+            }
+            if (this.plugin.getMVConfig().getJoinLocationOverride()) {
+                Logging.fine("Moving player to preset join location: " + this.plugin.getMVConfig().getJoinLocation());
+                this.sendPlayerToJoinLocation(p);
             }
         }
         // Handle the Players GameMode setting for the new world.
@@ -326,6 +331,22 @@ public class MVPlayerListener implements Listener {
                     player.teleport(plugin.getMVWorldManager().getFirstSpawnWorld().getSpawnLocation());
                 }
             }, 1L);
+    }
+
+    private void sendPlayerToJoinLocation(final Player player) {
+        // Remove the player 1 tick after the login. I'm sure there's GOT to be a better way to do this...
+        this.plugin.getServer().getScheduler().scheduleSyncDelayedTask(this.plugin,
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        Location joinLocation = plugin.getMVWorldManager().getJoinLocation(player);
+                        if (joinLocation == null) {
+                            Logging.warning("Unable to teleport %s to NULL join location.", player.getName());
+                            return;
+                        }
+                        player.teleport(joinLocation);
+                    }
+                }, 1L);
     }
 
     // FOLLOWING 2 Methods and Private class handle Per Player GameModes.


### PR DESCRIPTION
basically just a very very simple "hub" feature, where players always join at a fix destination (uses MVDestinations). 2 new config will be added: `joinlocationoverride` and `joinlocation`. It works similar to firstspawnworld, just now it's every time the player joins.