### PR TITLE
Fix teleporting to the calling player's bed

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
@@ -23,8 +23,8 @@ import org.bukkit.util.Vector;
  * A bed-{@link MVDestination}.
  */
 public class BedDestination implements MVDestination {
-    public static final String CALLER_BED_NAME = "my-bed";
-    public static final String CALLER_BED_STRING = "b:" + CALLER_BED_NAME;
+    public static final String CALLER_BED_STRING = "my-bed";
+    public static final String OLD_BED_STRING = "playerbed";
     private String playername = "";
     private boolean isValid;
     private Location knownBedLoc;
@@ -47,11 +47,11 @@ public class BedDestination implements MVDestination {
         boolean validFormat = split.length >= 1 && split.length <= 2 && split[0].equals(this.getIdentifier());
 
         OfflinePlayer p = Bukkit.getOfflinePlayer(split[1]);
-        boolean validPlayer = p.getName() != null && !p.getName().equals(CALLER_BED_NAME);
+        boolean validPlayer = p.getName() != null && !(p.getName().equals(OLD_BED_STRING) || p.getName().equals(CALLER_BED_STRING));
 
         if (validFormat && validPlayer) this.playername = p.getName();
 
-        this.isValid = destination.equals(CALLER_BED_STRING) || (validFormat && validPlayer);
+        this.isValid = destination.equals("b:" + CALLER_BED_STRING) || destination.equals("b:" + OLD_BED_STRING) || (validFormat && validPlayer);
 
         return this.isValid;
     }
@@ -137,6 +137,6 @@ public class BedDestination implements MVDestination {
 
     @Override
     public String toString() {
-        return playername.isEmpty() ? CALLER_BED_STRING : ("b:" + playername);
+        return "b:" + (playername.isEmpty() ? CALLER_BED_STRING : playername);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
@@ -23,7 +23,8 @@ import org.bukkit.util.Vector;
  * A bed-{@link MVDestination}.
  */
 public class BedDestination implements MVDestination {
-    public static final String OLD_BED_STRING = "b:playerbed";
+    public static final String CALLER_BED_NAME = "my-bed";
+    public static final String CALLER_BED_STRING = "b:" + CALLER_BED_NAME;
     private String playername = "";
     private boolean isValid;
     private Location knownBedLoc;
@@ -46,11 +47,11 @@ public class BedDestination implements MVDestination {
         boolean validFormat = split.length >= 1 && split.length <= 2 && split[0].equals(this.getIdentifier());
 
         OfflinePlayer p = Bukkit.getOfflinePlayer(split[1]);
-        boolean validPlayer = p.getName() != null && !p.getName().equals("playerbed");
+        boolean validPlayer = p.getName() != null && !p.getName().equals(CALLER_BED_NAME);
 
         if (validFormat && validPlayer) this.playername = p.getName();
 
-        this.isValid = destination.equals(OLD_BED_STRING) || (validFormat && validPlayer);
+        this.isValid = destination.equals(CALLER_BED_STRING) || (validFormat && validPlayer);
 
         return this.isValid;
     }
@@ -136,6 +137,6 @@ public class BedDestination implements MVDestination {
 
     @Override
     public String toString() {
-        return playername.isEmpty() ? OLD_BED_STRING : ("b:" + playername);
+        return playername.isEmpty() ? CALLER_BED_STRING : ("b:" + playername);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
@@ -23,7 +23,6 @@ import org.bukkit.util.Vector;
  * A bed-{@link MVDestination}.
  */
 public class BedDestination implements MVDestination {
-    public static final String CALLER_BED_STRING = "my-bed";
     public static final String OLD_BED_STRING = "playerbed";
     private String playername = "";
     private boolean isValid;
@@ -47,11 +46,11 @@ public class BedDestination implements MVDestination {
         boolean validFormat = split.length >= 1 && split.length <= 2 && split[0].equals(this.getIdentifier());
 
         OfflinePlayer p = Bukkit.getOfflinePlayer(split[1]);
-        boolean validPlayer = p.getName() != null && !(p.getName().equals(OLD_BED_STRING) || p.getName().equals(CALLER_BED_STRING));
+        boolean validPlayer = p.getName() != null && !p.getName().equals(OLD_BED_STRING);
 
         if (validFormat && validPlayer) this.playername = p.getName();
 
-        this.isValid = destination.equals("b:" + CALLER_BED_STRING) || destination.equals("b:" + OLD_BED_STRING) || (validFormat && validPlayer);
+        this.isValid = destination.equals("b:" + OLD_BED_STRING) || (validFormat && validPlayer);
 
         return this.isValid;
     }
@@ -137,6 +136,6 @@ public class BedDestination implements MVDestination {
 
     @Override
     public String toString() {
-        return "b:" + (playername.isEmpty() ? CALLER_BED_STRING : playername);
+        return "b:" + (playername.isEmpty() ? OLD_BED_STRING : playername);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
@@ -23,7 +23,7 @@ import org.bukkit.util.Vector;
  * A bed-{@link MVDestination}.
  */
 public class BedDestination implements MVDestination {
-    public static final String OLD_BED_STRING = "playerbed";
+    public static final String OWN_BED_STRING = "playerbed";
     private String playername = "";
     private boolean isValid;
     private Location knownBedLoc;
@@ -46,11 +46,11 @@ public class BedDestination implements MVDestination {
         boolean validFormat = split.length >= 1 && split.length <= 2 && split[0].equals(this.getIdentifier());
 
         OfflinePlayer p = Bukkit.getOfflinePlayer(split[1]);
-        boolean validPlayer = p.getName() != null && !p.getName().equals(OLD_BED_STRING);
+        boolean validPlayer = p.getName() != null && !p.getName().equals(OWN_BED_STRING);
 
         if (validFormat && validPlayer) this.playername = p.getName();
 
-        this.isValid = destination.equals("b:" + OLD_BED_STRING) || (validFormat && validPlayer);
+        this.isValid = destination.equals("b:" + OWN_BED_STRING) || (validFormat && validPlayer);
 
         return this.isValid;
     }
@@ -136,6 +136,6 @@ public class BedDestination implements MVDestination {
 
     @Override
     public String toString() {
-        return "b:" + (playername.isEmpty() ? OLD_BED_STRING : playername);
+        return "b:" + (playername.isEmpty() ? OWN_BED_STRING : playername);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/BedDestination.java
@@ -46,7 +46,7 @@ public class BedDestination implements MVDestination {
         boolean validFormat = split.length >= 1 && split.length <= 2 && split[0].equals(this.getIdentifier());
 
         OfflinePlayer p = Bukkit.getOfflinePlayer(split[1]);
-        boolean validPlayer = (p != null);
+        boolean validPlayer = p.getName() != null && !p.getName().equals("playerbed");
 
         if (validFormat && validPlayer) this.playername = p.getName();
 


### PR DESCRIPTION
When using the bed destination, the player's name would always be set causing the `b:playerbed` to not work. This adds an extra check to see if the player's name is `playerbed`. I also added the ability to use `b:my-bed` since it is an invalid player name and will never collide with an actual player' username (assuming Mojang/Microsoft doesn't change the username requirements).