### PR TITLE
Fix cannot remove block currency with mvm set command.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/configuration/EntryFee.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/configuration/EntryFee.java
@@ -22,6 +22,8 @@ public class EntryFee extends SerializationConfig {
     @Nullable
     private Material currency;
 
+    private final Material DISABLED_MATERIAL = Material.AIR;
+
     public EntryFee() {
         super();
     }
@@ -51,6 +53,9 @@ public class EntryFee extends SerializationConfig {
      */
     @Nullable
     public Material getCurrency() {
+        if (currency == null || currency.equals(DISABLED_MATERIAL)) {
+            return null;
+        }
         return currency;
     }
 

--- a/src/test/java/com/onarandombox/MultiverseCore/TestEntryFeeConversion.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestEntryFeeConversion.java
@@ -50,6 +50,10 @@ public class TestEntryFeeConversion {
         WorldProperties props = new WorldProperties(config);
         assertNull(props.entryfee.getCurrency());
 
+        entryFee.put("currency", 0);
+        props = new WorldProperties(config);
+        assertNull(props.entryfee.getCurrency());
+
         entryFee.put("currency", 1);
         props = new WorldProperties(config);
         assertEquals(Material.STONE, props.entryfee.getCurrency());


### PR DESCRIPTION
Fixes #2484.

To remove use of block currency we are supposed to set the property to `-1`. However, `-1` is an invalid material type so you cannot run `/mvm set currency -1 [worldname]`. 

Looking into the code, to allow `-1` as expection is probably going to be hard, so I changed it to **setting currency to `0` is now considered as no currency value.** Since, materialID `0` is just AIR, it should be ok. (doubt anyone set air as currency 😆)


Wiki will need to change as well to reflect this.