### PR TITLE
Use getPlayerExact instead of getPlayer

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CheckCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CheckCommand.java
@@ -37,7 +37,7 @@ public class CheckCommand extends MultiverseCommand {
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        Player p = this.plugin.getServer().getPlayer(args.get(0));
+        Player p = this.plugin.getServer().getPlayerExact(args.get(0));
         if (p == null) {
             sender.sendMessage("Could not find player " + ChatColor.GREEN + args.get(0));
             sender.sendMessage("Are they online?");

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/SpawnCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/SpawnCommand.java
@@ -50,7 +50,7 @@ public class SpawnCommand extends MultiverseCommand {
                 sender.sendMessage("You don't have permission to teleport another player to spawn. (multiverse.core.spawn.other)");
                 return;
             }
-            Player target = this.plugin.getServer().getPlayer(args.get(0));
+            Player target = this.plugin.getServer().getPlayerExact(args.get(0));
             if (target != null) {
                 target.sendMessage("Teleporting to this world's spawn...");
                 spawnAccurately(target);

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
@@ -58,7 +58,7 @@ public class TeleportCommand extends MultiverseCommand {
         String destinationName;
 
         if (args.size() == 2) {
-            teleportee = this.plugin.getServer().getPlayer(args.get(0));
+            teleportee = this.plugin.getServer().getPlayerExact(args.get(0));
             if (teleportee == null) {
                 this.messaging.sendMessage(sender, String.format("Sorry, I couldn't find player: %s%s",
                         ChatColor.GOLD, args.get(0)), false);

--- a/src/main/java/com/onarandombox/MultiverseCore/destination/PlayerDestination.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/destination/PlayerDestination.java
@@ -50,7 +50,7 @@ public class PlayerDestination implements MVDestination {
      */
     @Override
     public Location getLocation(Entity e) {
-        Player p = plugin.getServer().getPlayer(this.player);
+        Player p = plugin.getServer().getPlayerExact(this.player);
         Player plLoc = null;
         if (e instanceof Player) {
             plLoc = (Player) e;

--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
@@ -169,7 +169,7 @@ public class MVPlayerListener implements Listener {
                 this.plugin.log(Level.FINER, "We know the teleporter is the console! Magical!");
                 teleporter = this.plugin.getServer().getConsoleSender();
             } else {
-                teleporter = this.plugin.getServer().getPlayer(teleporterName);
+                teleporter = this.plugin.getServer().getPlayerExact(teleporterName);
             }
         }
         this.plugin.log(Level.FINER, "Inferred sender '" + teleporter + "' from name '"


### PR DESCRIPTION
`getPlayer` searches for usernames instead of performing a lookup. I tested this by running `/mv check nicegamer world` (my username is `nicegamer7`, not `nicegamer`), and the command ran successfully as if I had entered `nicegamer7`.

This is counter intuitive, so I've changed all occurrences of `getPlayer` to `getPlayerExact` (which is still case insensitive). I did this by searching the codebase with this regex:
```
getPlayer\([^\)]
```
Also, a lookup is obviously faster than searching, so there's that.