### PR TITLE
Update bStats Metrics Class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.7</version>
+            <version>1.8</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.bukkit</groupId>


### PR DESCRIPTION
bStats just released version 1.8 of the metrics class. This update helps reduce load on the bStats backend!