### PR TITLE
Add a Config Option to Disable Buscript

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -353,13 +353,16 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
      * Initializes the buscript javascript library.
      */
     private void initializeBuscript() {
-        try {
-            buscript = new Buscript(this);
-            // Add global variable "multiverse" to javascript environment
-            buscript.setScriptVariable("multiverse", this);
-        } catch (NullPointerException e) {
-            buscript = null;
-            Logging.warning("Buscript failed to load! The script command will be disabled!");
+        buscript = null;
+
+        if (this.getMVConfig().getEnableBuscript()) {
+            try {
+                buscript = new Buscript(this);
+                // Add global variable "multiverse" to javascript environment
+                buscript.setScriptVariable("multiverse", this);
+            } catch (NullPointerException e) {
+                Logging.warning("Buscript failed to load! The script command will be disabled!");
+            }
         }
     }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
@@ -56,6 +56,8 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Property
     private volatile boolean displaypermerrors;
     @Property
+    private volatile boolean enablebuscript;
+    @Property
     private volatile int globaldebug;
     @Property
     private volatile boolean silentstart;
@@ -99,6 +101,7 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
         teleportintercept = true;
         firstspawnoverride = true;
         displaypermerrors = true;
+        enablebuscript = true;
         globaldebug = 0;
         messagecooldown = 5000;
         teleportcooldown = 1000;
@@ -211,6 +214,22 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Override
     public boolean getDisplayPermErrors() {
         return this.displaypermerrors;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getEnableBuscript() {
+        return this.enablebuscript;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEnableBuscript(boolean enableBuscript) {
+        this.enablebuscript = enableBuscript;
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
@@ -87,6 +87,18 @@ public interface MultiverseCoreConfig extends ConfigurationSerializable {
     boolean getDisplayPermErrors();
 
     /**
+     * Sets enableBuscript.
+     * @param enableBuscript The new value.
+     */
+    void setEnableBuscript(boolean enableBuscript);
+
+    /**
+     * Gets enableBuscript.
+     * @return enableBuscript.
+     */
+    boolean getEnableBuscript();
+
+    /**
      * Sets firstSpawnOverride.
      * @param firstSpawnOverride The new value.
      */

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/VersionCommand.java
@@ -64,6 +64,7 @@ public class VersionCommand extends MultiverseCommand {
                 + "[Multiverse-Core]   teleportintercept: " + plugin.getMVConfig().getTeleportIntercept() + '\n'
                 + "[Multiverse-Core]   firstspawnoverride: " + plugin.getMVConfig().getFirstSpawnOverride() + '\n'
                 + "[Multiverse-Core]   displaypermerrors: " + plugin.getMVConfig().getDisplayPermErrors() + '\n'
+                + "[Multiverse-Core]   enablebuscript: " + plugin.getMVConfig().getEnableBuscript() + '\n'
                 + "[Multiverse-Core]   globaldebug: " + plugin.getMVConfig().getGlobalDebug() + '\n'
                 + "[Multiverse-Core]   silentstart: " + plugin.getMVConfig().getSilentStart() + '\n'
                 + "[Multiverse-Core]   messagecooldown: " + plugin.getMessaging().getCooldown() + '\n'


### PR DESCRIPTION
This PR adds a config option to enable/disable Buscript. This was requested on the Spigot thread, so that users can have a way of removing the warning from the console (the one that pops up when Buscript can't be initialized).