### PR TITLE
Add support for fullname face direction.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/utils/SimpleLocationManipulation.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/SimpleLocationManipulation.java
@@ -40,6 +40,15 @@ public class SimpleLocationManipulation implements LocationManipulation {
         orientationInts.put("w", 90);
         orientationInts.put("nw", 135);
 
+        orientationInts.put("north", 180);
+        orientationInts.put("northeast", 225);
+        orientationInts.put("east", 270);
+        orientationInts.put("southeast", 315);
+        orientationInts.put("south", 0);
+        orientationInts.put("southwest", 45);
+        orientationInts.put("west", 90);
+        orientationInts.put("northwest", 135);
+
         // "freeze" the map:
         ORIENTATION_INTS = Collections.unmodifiableMap(orientationInts);
         // END CHECKSTYLE-SUPPRESSION: MagicNumberCheck


### PR DESCRIPTION
See a few people is discord typing `north` instead of `n` for facing direction. Figured why not just add support for it, so we can do `w:world:north` on top of the current `w:world:n`.