### PR TITLE
Fix compiling with Java 11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -264,13 +264,19 @@
             <plugin>
                 <groupId>se.eris</groupId>
                 <artifactId>notnull-instrumenter-maven-plugin</artifactId>
-                <version>0.6.8</version>
+                <version>1.0.0</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>instrument</goal>
                             <goal>tests-instrument</goal>
                         </goals>
+                        <configuration>
+                            <notNull>
+                                <param>org.jetbrains.annotations.NotNull</param>
+                                <param>javax.validation.constraints.NotNull</param>
+                            </notNull>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -359,21 +359,21 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.9</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-easymock</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.9</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.9</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/com/onarandombox/MultiverseCore/utils/TestInstanceCreator.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/utils/TestInstanceCreator.java
@@ -214,11 +214,18 @@ public class TestInstanceCreator {
             serverfield.set(core, mockServer);
 
             // Set buscript
-            Buscript buscript = PowerMockito.spy(new Buscript(core));
+            Buscript buscript;
             Field buscriptfield = MultiverseCore.class.getDeclaredField("buscript");
             buscriptfield.setAccessible(true);
+
+            try {
+                buscript = PowerMockito.spy(new Buscript(core));
+                when(buscript.getPlugin()).thenReturn(core);
+            } catch (NullPointerException e) {
+                buscript = null;
+            }
+
             buscriptfield.set(core, buscript);
-            when(buscript.getPlugin()).thenReturn(core);
 
             // Set worldManager
             WorldManager wm = PowerMockito.spy(new WorldManager(core));


### PR DESCRIPTION
Fixes #2559. The issue was the notnull-instrumenter-maven-plugin version we used didn't have java 11+ support, so needed to bump to v1.0.0 (https://github.com/osundblad/intellij-annotations-instrumenter-maven-plugin). There were shading issues, but apparently bumping maven-shaded-plugin to `3.2.4` solved it.