### PR TITLE
Add ability to keep gamerules setting on world regen.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -1131,12 +1131,22 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
 
     /**
      * {@inheritDoc}
-     * @deprecated This is deprecated!
+     * @deprecated This is deprecated! Do not use!
      */
     @Override
     @Deprecated
     public Boolean regenWorld(String name, Boolean useNewSeed, Boolean randomSeed, String seed) {
-        return this.worldManager.regenWorld(name, useNewSeed, randomSeed, seed);
+        return this.worldManager.regenWorld(name, useNewSeed, randomSeed, seed, false);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @deprecated This is deprecated! Do not use!
+     */
+    @Override
+    @Deprecated
+    public Boolean regenWorld(String name, Boolean useNewSeed, Boolean randomSeed, String seed, Boolean keepGameRules) {
+        return this.worldManager.regenWorld(name, useNewSeed, randomSeed, seed, keepGameRules);
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/api/Core.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/Core.java
@@ -126,19 +126,37 @@ public interface Core {
     AnchorManager getAnchorManager();
 
     /**
-     * Used by queued commands to regenerate a world on a delay.
+     * Previously used by queued commands to regenerate a world on a delay.
+     * Do not use api method for any other purpose.
      *
-     * @param name Name of the world to regenerate
-     * @param useNewSeed If a new seed should be used
-     * @param randomSeed IF the new seed should be random
-     * @param seed The seed of the world.
+     * @param name          Name of the world to regenerate
+     * @param useNewSeed    If a new seed should be used
+     * @param randomSeed    If the new seed should be random
+     * @param seed          The seed of the world.
      *
      * @return True if success, false if fail.
      *
-     * @deprecated Use {@link MVWorldManager#regenWorld(String, boolean, boolean, String)} instead.
+     * @deprecated Use {@link MVWorldManager#regenWorld(String, boolean, boolean, String, boolean)} instead.
      */
     @Deprecated
     Boolean regenWorld(String name, Boolean useNewSeed, Boolean randomSeed, String seed);
+
+    /**
+     * Used by queued commands to regenerate a world on a delay.
+     * Do not use api method for any other purpose.
+     *
+     * @param name          Name of the world to regenerate
+     * @param useNewSeed    If a new seed should be used
+     * @param randomSeed    If the new seed should be random
+     * @param seed          The seed of the world.
+     * @param keepGameRules If GameRules should be kept on world regen.
+     *
+     * @return True if success, false if fail.
+     *
+     * @deprecated Use {@link MVWorldManager#regenWorld(String, boolean, boolean, String, boolean)} instead.
+     */
+    @Deprecated
+    Boolean regenWorld(String name, Boolean useNewSeed, Boolean randomSeed, String seed, Boolean keepGameRules);
 
     /**
      * Decrements the number of plugins that have specifically hooked into core.

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
@@ -313,14 +313,27 @@ public interface MVWorldManager {
     /**
      * Regenerates a world.
      *
-     * @param name Name of the world to regenerate
-     * @param useNewSeed If a new seed should be used
-     * @param randomSeed IF the new seed should be random
-     * @param seed The seed of the world.
+     * @param name          Name of the world to regenerate
+     * @param useNewSeed    If a new seed should be used
+     * @param randomSeed    If the new seed should be random
+     * @param seed          The seed of the world.
      *
      * @return True if success, false if fail.
      */
     boolean regenWorld(String name, boolean useNewSeed, boolean randomSeed, String seed);
+
+    /**
+     * Regenerates a world.
+     *
+     * @param name          Name of the world to regenerate
+     * @param useNewSeed    If a new seed should be used
+     * @param randomSeed    If the new seed should be random
+     * @param seed          The seed of the world.
+     * @param keepGameRules If GameRules should be kept on world regen.
+     *
+     * @return True if success, false if fail.
+     */
+    boolean regenWorld(String name, boolean useNewSeed, boolean randomSeed, String seed, boolean keepGameRules);
 
     boolean isKeepingSpawnInMemory(World world);
     

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
@@ -9,12 +9,12 @@ package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.commandtools.queue.QueuedCommand;
+import com.pneumaticraft.commandhandler.CommandHandler;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.permissions.PermissionDefault;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -25,8 +25,8 @@ public class RegenCommand extends MultiverseCommand {
     public RegenCommand(MultiverseCore plugin) {
         super(plugin);
         this.setName("Regenerates a World");
-        this.setCommandUsage("/mv regen" + ChatColor.GREEN + " {WORLD}" + ChatColor.GOLD + " [-s [SEED]]");
-        this.setArgRange(1, 3);
+        this.setCommandUsage("/mv regen" + ChatColor.GREEN + " {WORLD}" + ChatColor.GOLD + " [-s [SEED]] [--keep-gamerules]");
+        this.setArgRange(1, 4);
         this.addKey("mvregen");
         this.addKey("mv regen");
         this.addCommandExample("You can use the -s with no args to get a new seed:");
@@ -43,10 +43,10 @@ public class RegenCommand extends MultiverseCommand {
         boolean useseed = (!(args.size() == 1));
         boolean randomseed = (args.size() == 2 && args.get(1).equalsIgnoreCase("-s"));
         String seed = (args.size() == 3) ? args.get(2) : "";
-
+        boolean keepGamerules = CommandHandler.hasFlag("--keep-gamerules", args);
         this.plugin.getCommandQueueManager().addToQueue(new QueuedCommand(
                 sender,
-                doWorldRegen(sender, worldName, useseed, randomseed, seed),
+                doWorldRegen(sender, worldName, useseed, randomseed, seed, keepGamerules),
                 String.format("Are you sure you want to regen '%s'? You cannot undo this action.", worldName)
         ));
     }
@@ -55,10 +55,11 @@ public class RegenCommand extends MultiverseCommand {
                                   @NotNull String worldName,
                                   boolean useSeed,
                                   boolean randomSeed,
-                                  @NotNull String seed) {
+                                  @NotNull String seed,
+                                  boolean keepGamerules) {
 
         return () -> {
-            if (this.plugin.getMVWorldManager().regenWorld(worldName, useSeed, randomSeed, seed)) {
+            if (this.plugin.getMVWorldManager().regenWorld(worldName, useSeed, randomSeed, seed, keepGamerules)) {
                 sender.sendMessage(ChatColor.GREEN + "World Regenerated!");
                 return;
             }


### PR DESCRIPTION
Fixes #2516. By default regening a world will keep the gamerule. If they don't want this behaviour, they can run with this new flag: `/mv regen <world> --reset-gamerules`.

I also did a bit of code cleanup in the regen method while at it.