### PR TITLE
Implement new queue command system.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -68,6 +68,7 @@ import com.onarandombox.MultiverseCore.commands.TeleportCommand;
 import com.onarandombox.MultiverseCore.commands.UnloadCommand;
 import com.onarandombox.MultiverseCore.commands.VersionCommand;
 import com.onarandombox.MultiverseCore.commands.WhoCommand;
+import com.onarandombox.MultiverseCore.commandtools.queue.CommandQueueManager;
 import com.onarandombox.MultiverseCore.destination.AnchorDestination;
 import com.onarandombox.MultiverseCore.destination.BedDestination;
 import com.onarandombox.MultiverseCore.destination.CannonDestination;
@@ -204,6 +205,7 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
 
     // Setup our Map for our Commands using the CommandHandler.
     private CommandHandler commandHandler;
+    private CommandQueueManager commandQueueManager;
 
     private static final String LOG_TAG = "[Multiverse-Core]";
 
@@ -288,6 +290,7 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
 
         // Setup the command manager
         this.commandHandler = new CommandHandler(this, this.ph);
+        this.commandQueueManager = new CommandQueueManager(this);
         // Call the Function to assign all the Commands to their Class.
         this.registerCommands();
 
@@ -915,6 +918,15 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
     @Override
     public CommandHandler getCommandHandler() {
         return this.commandHandler;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Deprecated
+    public CommandQueueManager getCommandQueueManager() {
+        return commandQueueManager;
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/api/Core.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/Core.java
@@ -8,6 +8,7 @@
 package com.onarandombox.MultiverseCore.api;
 
 import buscript.Buscript;
+import com.onarandombox.MultiverseCore.commandtools.queue.CommandQueueManager;
 import com.onarandombox.MultiverseCore.destination.DestinationFactory;
 import com.onarandombox.MultiverseCore.utils.AnchorManager;
 import com.onarandombox.MultiverseCore.utils.MVEconomist;
@@ -85,6 +86,15 @@ public interface Core {
      * @return A non-null {@link CommandHandler}.
      */
     CommandHandler getCommandHandler();
+
+    /**
+     * Manager for command that requires /mv confirm before execution.
+     *
+     * @return A non-null {@link CommandQueueManager}.
+     * @deprecated To be moved to new command manager in 5.0.0
+     */
+    @Deprecated
+    CommandQueueManager getCommandQueueManager();
 
     /**
      * Gets the factory class responsible for loading many different destinations

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ConfirmCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ConfirmCommand.java
@@ -33,7 +33,7 @@ public class ConfirmCommand extends MultiverseCommand {
 
     @Override
     public void runCommand(CommandSender sender, List<String> args) {
-        this.plugin.getCommandHandler().confirmQueuedCommand(sender);
+        this.plugin.getCommandQueueManager().runQueuedCommand(sender);
     }
 
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/CommandQueueManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/CommandQueueManager.java
@@ -1,0 +1,158 @@
+/******************************************************************************
+ * Multiverse 2 Copyright (c) the Multiverse Team 2020.                       *
+ * Multiverse 2 is licensed under the BSD License.                            *
+ * For more information please check the README.md file included              *
+ * with this project.                                                         *
+ ******************************************************************************/
+
+package com.onarandombox.MultiverseCore.commandtools.queue;
+
+import com.dumptruckman.minecraft.util.Logging;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.block.data.type.CommandBlock;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.CommandSender;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Managers the queuing of dangerous commands that needs to use '/mv confirm' before executing.
+ */
+public class CommandQueueManager {
+
+    private static final long TICKS_PER_SECOND = 20;
+    private static final DummyCommandBlockSender COMMAND_BLOCK = new DummyCommandBlockSender();
+
+    private final MultiverseCore plugin;
+    private final Map<CommandSender, QueuedCommand> queuedCommandMap;
+
+    public CommandQueueManager(@NotNull MultiverseCore plugin) {
+        this.plugin = plugin;
+        this.queuedCommandMap = new WeakHashMap<>();
+    }
+
+    /**
+     * Adds a queue command into queue.
+     *
+     * @param queuedCommand The queue command to add.
+     */
+    public void addToQueue(QueuedCommand queuedCommand) {
+        CommandSender targetSender = parseSender(queuedCommand.getSender());
+
+        // Since only one command is stored in queue per sender, we remove the old one.
+        this.removeFromQueue(targetSender);
+
+        Logging.finer("Add new command to queue for sender %s.", targetSender);
+        this.queuedCommandMap.put(targetSender, queuedCommand);
+        queuedCommand.setExpireTask(runExpireLater(queuedCommand));
+
+        queuedCommand.getSender().sendMessage(queuedCommand.getPrompt());
+        queuedCommand.getSender().sendMessage(String.format("Run %s/mv confirm %sto continue. This will expire in %s seconds.",
+                ChatColor.GREEN, ChatColor.WHITE, queuedCommand.getValidDuration()));
+    }
+
+    /**
+     * Expire task that remove {@link QueuedCommand} from queue after valid duration defined.
+     *
+     * @param queuedCommand Command to run the expire task on.
+     * @return The expire {@link BukkitTask}.
+     */
+    @NotNull
+    private BukkitTask runExpireLater(@NotNull QueuedCommand queuedCommand) {
+        return Bukkit.getScheduler().runTaskLater(
+                this.plugin,
+                expireRunnable(queuedCommand),
+                queuedCommand.getValidDuration() * TICKS_PER_SECOND
+        );
+    }
+
+    /**
+     * Runnable responsible for expiring the queued command.
+     *
+     * @param queuedCommand Command to create the expire task on.
+     * @return The expire runnable.
+     */
+    @NotNull
+    private Runnable expireRunnable(@NotNull QueuedCommand queuedCommand) {
+        return () -> {
+            CommandSender targetSender = parseSender(queuedCommand.getSender());
+            QueuedCommand matchingQueuedCommand = this.queuedCommandMap.get(targetSender);
+            if (!queuedCommand.equals(matchingQueuedCommand) || queuedCommand.getExpireTask().isCancelled()) {
+                // To be safe, but this shouldn't happen since we cancel old commands before add new once.
+                Logging.finer("This is an old queue command already.");
+                return;
+            }
+            queuedCommand.getSender().sendMessage("Your queued command has expired.");
+            this.queuedCommandMap.remove(queuedCommand.getSender());
+        };
+    }
+
+    /**
+     * Runs the command in queue for the given sender, if any.
+     *
+     * @param sender    {@link CommandSender} that confirmed the command.
+     * @return True if queued command ran successfully, else false.
+     */
+    public boolean runQueuedCommand(@NotNull CommandSender sender) {
+        CommandSender targetSender = parseSender(sender);
+        QueuedCommand queuedCommand = this.queuedCommandMap.get(targetSender);
+        if (queuedCommand == null) {
+            sender.sendMessage(ChatColor.RED + "You do not have any commands in queue.");
+            return false;
+        }
+        Logging.finer("Running queued command...");
+        queuedCommand.getAction().run();
+        return removeFromQueue(targetSender);
+    }
+
+    /**
+     * Since only one command is stored in queue per sender, we remove the old one.
+     *
+     * @param sender    The {@link CommandSender} that executed the command.
+     * @return True if queue command is removed from sender successfully, else false.
+     */
+    public boolean removeFromQueue(@NotNull CommandSender sender) {
+        CommandSender targetSender = parseSender(sender);
+        QueuedCommand previousCommand = this.queuedCommandMap.remove(targetSender);
+        if (previousCommand == null) {
+            Logging.finer("No queue command to remove for sender %s.", targetSender.getName());
+            return false;
+        }
+        previousCommand.getExpireTask().cancel();
+        Logging.finer("Removed queue command for sender %s.", targetSender.getName());
+        return true;
+    }
+
+    /**
+     * To allow all CommandBlocks to be a common sender with use of {@link DummyCommandBlockSender}.
+     * So confirm command can be used for a queue command on another command block.
+     *
+     * @param sender    The sender to parse.
+     * @return The sender, or if its a command block, a {@link DummyCommandBlockSender}.
+     */
+    @NotNull
+    private CommandSender parseSender(@NotNull CommandSender sender) {
+        Logging.fine(sender.getClass().getName());
+        if (isCommandBlock(sender)) {
+            Logging.finer("Is command block.");
+            return COMMAND_BLOCK;
+        }
+        return sender;
+    }
+
+    /**
+     * Check if sender is a command block.
+     *
+     * @param sender    The sender to check on.
+     * @return True if sender is a command block, else false.
+     */
+    private boolean isCommandBlock(@NotNull CommandSender sender) {
+        return sender instanceof BlockCommandSender
+                && ((BlockCommandSender) sender).getBlock().getBlockData() instanceof CommandBlock;
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/DummyCommandBlockSender.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/DummyCommandBlockSender.java
@@ -1,0 +1,104 @@
+package com.onarandombox.MultiverseCore.commandtools.queue;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionAttachment;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+/**
+ * Used by {@link CommandQueueManager}, so different commands block can be recognised as one.
+ */
+class DummyCommandBlockSender implements CommandSender {
+
+    @Override
+    public void sendMessage(@NotNull String message) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void sendMessage(@NotNull String[] messages) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NotNull Server getServer() {
+        return Bukkit.getServer();
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "DummyCommandBlockSender";
+    }
+
+    @Override
+    public boolean isPermissionSet(@NotNull String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isPermissionSet(@NotNull Permission perm) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull Permission perm) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NotNull PermissionAttachment addAttachment(@NotNull Plugin plugin, @NotNull String name, boolean value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NotNull PermissionAttachment addAttachment(@NotNull Plugin plugin) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable PermissionAttachment addAttachment(@NotNull Plugin plugin, @NotNull String name, boolean value, int ticks) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @Nullable PermissionAttachment addAttachment(@NotNull Plugin plugin, int ticks) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAttachment(@NotNull PermissionAttachment attachment) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void recalculatePermissions() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public @NotNull Set<PermissionAttachmentInfo> getEffectivePermissions() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isOp() {
+        return true;
+    }
+
+    @Override
+    public void setOp(boolean value) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/QueuedCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/QueuedCommand.java
@@ -1,0 +1,86 @@
+/******************************************************************************
+ * Multiverse 2 Copyright (c) the Multiverse Team 2020.                       *
+ * Multiverse 2 is licensed under the BSD License.                            *
+ * For more information please check the README.md file included              *
+ * with this project.                                                         *
+ ******************************************************************************/
+
+package com.onarandombox.MultiverseCore.commandtools.queue;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a single command used in {@link CommandQueueManager} for confirming before running potentially
+ * dangerous action.
+ */
+public class QueuedCommand {
+
+    private static final String DEFAULT_PROMPT_MESSAGE = "The command you are trying to run is deemed dangerous.";
+    private static final int DEFAULT_VALID_TIME = 10;
+
+    private final CommandSender sender;
+    private final Runnable action;
+    private final String prompt;
+    private final int validDuration;
+    private BukkitTask expireTask;
+
+    public QueuedCommand(CommandSender sender, Runnable action) {
+        this(sender, action, DEFAULT_PROMPT_MESSAGE, DEFAULT_VALID_TIME);
+    }
+
+    public QueuedCommand(CommandSender sender, Runnable action, String prompt) {
+        this(sender, action, prompt, DEFAULT_VALID_TIME);
+    }
+
+    public QueuedCommand(CommandSender sender, Runnable action, int validDuration) {
+        this(sender, action, DEFAULT_PROMPT_MESSAGE, validDuration);
+    }
+
+    /**
+     * Creates a new queue command, to be registered at {@link CommandQueueManager#addToQueue(QueuedCommand)}.
+     *
+     * @param sender        The sender that ran the command needed for confirmation.
+     * @param action        The logic to execute upon confirming.
+     * @param prompt        Question to ask sender to confirm.
+     * @param validDuration Duration in which the command is valid for confirm in seconds.
+     */
+    public QueuedCommand(CommandSender sender, Runnable action, String prompt, int validDuration) {
+        this.sender = sender;
+        this.action = action;
+        this.prompt = prompt;
+        this.validDuration = validDuration;
+    }
+
+    @NotNull
+    CommandSender getSender() {
+        return sender;
+    }
+
+    @NotNull
+    String getPrompt() {
+        return prompt;
+    }
+
+    int getValidDuration() {
+        return validDuration;
+    }
+
+    @NotNull
+    Runnable getAction() {
+        return action;
+    }
+
+    @NotNull
+    BukkitTask getExpireTask() {
+        return expireTask;
+    }
+
+    void setExpireTask(@NotNull BukkitTask expireTask) {
+        if (this.expireTask != null) {
+            throw new IllegalStateException("This queue command already has an expire task. You can't register twice!");
+        }
+        this.expireTask = expireTask;
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/package-info.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Manager queuing of dangerous commands in need of confirmation.
+ */
+package com.onarandombox.MultiverseCore.commandtools.queue;


### PR DESCRIPTION
Primarily for ACF but I think we can implement this first. The main behaviour of it remains the same, needed to run `/mv confirm` before execution, and it expires after a certain period of time.

Here are some improvements/changes:
* `DummyCommandBlockSender` so that you can use one command block to run a dangerous command, and another to confirm it.
* Use a runnable instead of reflection.
* More customisable with a runnable, instead of just a success/fail message previously.