### PR TITLE
Small WorldManager updates

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
@@ -175,6 +175,16 @@ public interface MVWorldManager {
     MultiverseWorld getMVWorld(String name);
 
     /**
+     * Returns a {@link MultiverseWorld} if the world with name given exists, and null if it does not.
+     * This will search optionally for alias names.
+     *
+     * @param name          The name or optionally the alias of the world to get.
+     * @param checkAliases  Indicates whether to check for world alias name.
+     * @return A {@link MultiverseWorld} or null.
+     */
+    MultiverseWorld getMVWorld(String name, boolean checkAliases);
+
+    /**
      * Returns a {@link MultiverseWorld} if it exists, and null if it does not.
      *
      * @param world The Bukkit world to check.
@@ -183,12 +193,23 @@ public interface MVWorldManager {
     MultiverseWorld getMVWorld(World world);
 
     /**
-     * Checks to see if the given name is a valid {@link MultiverseWorld}.
+     * Checks to see if the given name is a valid {@link MultiverseWorld}
+     * Searches based on world name AND alias.
      *
      * @param name The name or alias of the world to check.
      * @return True if the world exists, false if not.
      */
     boolean isMVWorld(String name);
+
+    /**
+     * Checks to see if the given name is a valid {@link MultiverseWorld}.
+     * Optionally searches by alias is specified.
+     *
+     * @param name          The name or alias of the world to check.
+     * @param checkAliases  Indicates whether to check for world alias name.
+     * @return True if the world exists, false if not.
+     */
+    boolean isMVWorld(String name, boolean checkAliases);
 
     /**
      * Checks to see if the given world is a valid {@link MultiverseWorld}.

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
@@ -335,4 +335,11 @@ public interface MVWorldManager {
      * does not exist. {@code includeLoaded} if the world exists and is loaded.
      */
     boolean hasUnloadedWorld(String name, boolean includeLoaded);
+
+    /**
+     * Get all the possible worlds that Multiverse has detected to be importable.
+     *
+     * @return A collection of world names that are deemed importable.
+     */
+    Collection<String> getPotentialWorlds();
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
@@ -9,7 +9,6 @@ package com.onarandombox.MultiverseCore.commands;
 
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MVWorldManager;
-import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.utils.WorldNameChecker;
 import com.pneumaticraft.commandhandler.CommandHandler;
 import org.bukkit.ChatColor;
@@ -19,8 +18,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.permissions.PermissionDefault;
 
 import java.io.File;
-import java.io.FilenameFilter;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -46,33 +43,17 @@ public class ImportCommand extends MultiverseCommand {
         this.worldManager = this.plugin.getMVWorldManager();
     }
 
-    private String getPotentialWorlds() {
-        File worldFolder = this.plugin.getServer().getWorldContainer();
-        if (worldFolder == null) {
-            return "";
-        }
-        File[] files = worldFolder.listFiles();
-        String worldList = "";
-        Collection<MultiverseWorld> worlds = this.worldManager.getMVWorlds();
-        List<String> worldStrings = new ArrayList<String>();
-        for (MultiverseWorld world : worlds) {
-            worldStrings.add(world.getName());
-        }
-        for (String world : this.worldManager.getUnloadedWorlds()) {
-            worldStrings.add(world);
-        }
+    private String getPotentialWorldStrings() {
+        final Collection<String> potentialWorlds = this.worldManager.getPotentialWorlds();
+        StringBuilder worldList = new StringBuilder();
         ChatColor currColor = ChatColor.WHITE;
-        for (File file : files) {
-            if (file.isDirectory() && WorldNameChecker.isValidWorldFolder(file) && !worldStrings.contains(file.getName())) {
-                worldList += currColor + file.getName() + " ";
-                if (currColor == ChatColor.WHITE) {
-                    currColor = ChatColor.YELLOW;
-                } else {
-                    currColor = ChatColor.WHITE;
-                }
-            }
+
+        for (String world : potentialWorlds) {
+            worldList.append(currColor).append(world).append(' ');
+            currColor = currColor == ChatColor.WHITE ? ChatColor.YELLOW : ChatColor.WHITE;
         }
-        return worldList;
+
+        return worldList.toString();
     }
     
     private String trimWorldName(String userInput) {
@@ -85,7 +66,7 @@ public class ImportCommand extends MultiverseCommand {
         String worldName = trimWorldName(args.get(0));
 
         if (worldName.toLowerCase().equals("--list") || worldName.toLowerCase().equals("-l")) {
-            String worldList = this.getPotentialWorlds();
+            String worldList = this.getPotentialWorldStrings();
             if (worldList.length() > 2) {
                 sender.sendMessage(ChatColor.AQUA + "====[ These look like worlds ]====");
                 sender.sendMessage(worldList);
@@ -128,7 +109,7 @@ public class ImportCommand extends MultiverseCommand {
 
         if (!worldFile.exists()) {
             sender.sendMessage(ChatColor.RED + "FAILED.");
-            String worldList = this.getPotentialWorlds();
+            String worldList = this.getPotentialWorldStrings();
             sender.sendMessage("That world folder does not exist. These look like worlds to me:");
             sender.sendMessage(worldList);
         } else if (!WorldNameChecker.isValidWorldFolder(worldFile)) {

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -617,6 +617,14 @@ public class WorldManager implements MVWorldManager {
      */
     @Override
     public MultiverseWorld getMVWorld(String name) {
+        return this.getMVWorld(name, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MultiverseWorld getMVWorld(String name, boolean checkAliases) {
         if (name == null) {
             return null;
         }
@@ -624,7 +632,7 @@ public class WorldManager implements MVWorldManager {
         if (world != null) {
             return world;
         }
-        return this.getMVWorldByAlias(name);
+        return (checkAliases) ? this.getMVWorldByAlias(name) : null;
     }
 
     /**
@@ -633,7 +641,7 @@ public class WorldManager implements MVWorldManager {
     @Override
     public MultiverseWorld getMVWorld(World world) {
         if (world != null) {
-            return this.getMVWorld(world.getName());
+            return this.getMVWorld(world.getName(), false);
         }
         return null;
     }
@@ -658,7 +666,15 @@ public class WorldManager implements MVWorldManager {
      */
     @Override
     public boolean isMVWorld(final String name) {
-        return (this.worlds.containsKey(name) || isMVWorldAlias(name));
+        return this.isMVWorld(name, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isMVWorld(final String name, boolean checkAliases) {
+        return this.worlds.containsKey(name) || (checkAliases && this.isMVWorldAlias(name));
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -36,19 +36,19 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.Stack;
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Public facing API to add/remove Multiverse worlds.
@@ -956,4 +956,21 @@ public class WorldManager implements MVWorldManager {
 		}
 		return false;
 	}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+	public Collection<String> getPotentialWorlds() {
+        File worldContainer = this.plugin.getServer().getWorldContainer();
+        if (worldContainer == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(worldContainer.listFiles())
+                .filter(File::isDirectory)
+                .filter(folder -> !this.isMVWorld(folder.getName(), false))
+                .filter(WorldNameChecker::isValidWorldFolder)
+                .map(File::getName)
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
* Some operations do not need to lookup of MVWorld by alias, e.g. when its the bukkit world object or folder name. Since alias is by iteration, it saves performance to not do this check whenever possible.
* Make use of the new WorldNameChecker and added getPotentialWorlds method to WorldManager. More streamlined and useful for tab-complete in ACF.