### PR TITLE
Make UUID regex less restrictive.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/utils/PlayerFinder.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/PlayerFinder.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  */
 public class PlayerFinder {
 
-    private static final Pattern UUID_REGEX = Pattern.compile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[34][0-9a-fA-F]{3}-[89ab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}");
+    private static final Pattern UUID_REGEX = Pattern.compile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
     private static final Pattern COMMA_SPLIT = Pattern.compile(",");
 
     /**


### PR DESCRIPTION
As @nicegamer7 point out in https://github.com/Multiverse/Multiverse-Core/pull/2567#discussion_r589683007, software such as Floodgate have non-standard mc UUIDs, so we should be less strict during UUID regex check.