### PR TITLE
Make prefixchat config option default to 'false'

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
@@ -96,7 +96,7 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
         // BEGIN CHECKSTYLE-SUPPRESSION: MagicNumberCheck
         enforceaccess = false;
         useasyncchat = true;
-        prefixchat = true;
+        prefixchat = false;
         prefixchatformat = "[%world%]%chat%";
         teleportintercept = true;
         firstspawnoverride = true;


### PR DESCRIPTION
This may seem like a really negligible change but having this option default to `true` actually causes a lot of pain for support in other plugins that deal with prefixes (LuckPerms and Essentials being the main victims). Users always come in guns blazing, screaming at us because they don't know how to remove the world name from their chat. It's such a simple solution, yet no one thinks that of all plugins, it would be Multiverse that is tainting their beloved chat format.

Please consider updating this default setting. It will save a lot of us trouble in the future 🙏