### PR TITLE
General Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
             <id>minebench-repo</id>
             <url>https://repo.minebench.de/</url>
         </repository>
-        <repository>
-            <id>CodeMC</id>
-            <url>https://repo.codemc.org/repository/maven-public</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -325,13 +321,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.8</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.bukkit</groupId>
-                    <artifactId>bukkit</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.dumptruckman.minecraft</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
         <repository>
-            <id>vault-repo</id>
-            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
         <repository>
             <id>minebench-repo</id>
@@ -302,7 +302,7 @@
         <!-- End of SerializationConfig Dependency -->
         <!-- Start of Economy Dependency -->
         <dependency>
-            <groupId>net.milkbowl.vault</groupId>
+            <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7</version>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <minimizeJar>true</minimizeJar>
                             <relocations>
                                 <relocation>
                                     <pattern>me.main__.util</pattern>

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -364,7 +364,9 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
                 // Add global variable "multiverse" to javascript environment
                 buscript.setScriptVariable("multiverse", this);
             } catch (NullPointerException e) {
-                Logging.warning("Buscript failed to load! The script command will be disabled!");
+                Logging.warning("Buscript failed to load! The script command will be disabled! " +
+                        "If you would like not to see this message, " +
+                        "use `/mv conf enablebuscript false` to disable Buscript from loading.");
             }
         }
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -129,7 +129,7 @@ public class WorldManager implements MVWorldManager {
         }
 
         // Check for valid world name
-        if (!(WorldNameChecker.isValidWorldName(oldName) && WorldNameChecker.isValidWorldName(oldName))) {
+        if (!(WorldNameChecker.isValidWorldName(oldName) && WorldNameChecker.isValidWorldName(newName))) {
             return false;
         }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/metrics/MetricsHelper.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/metrics/MetricsHelper.java
@@ -1,10 +1,11 @@
 package com.onarandombox.MultiverseCore.utils.metrics;
 
+import org.bstats.charts.AdvancedPie;
+import org.bstats.charts.MultiLineChart;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
-
-import org.bstats.bukkit.Metrics;
 
 enum MetricsHelper {
     ;
@@ -17,16 +18,16 @@ enum MetricsHelper {
         map.put(key, count + 1);
     }
 
-    static Metrics.AdvancedPie createAdvancedPieChart(String chartId, Consumer<Map<String, Integer>> metricsFunc) {
+    static AdvancedPie createAdvancedPieChart(String chartId, Consumer<Map<String, Integer>> metricsFunc) {
         Map<String, Integer> map = new HashMap<>();
         metricsFunc.accept(map);
-        return new Metrics.AdvancedPie(chartId, () -> map);
+        return new AdvancedPie(chartId, () -> map);
     }
 
-    static Metrics.MultiLineChart createMultiLineChart(String chartId, Consumer<Map<String, Integer>> metricsFunc) {
+    static MultiLineChart createMultiLineChart(String chartId, Consumer<Map<String, Integer>> metricsFunc) {
         Map<String, Integer> map = new HashMap<>();
         metricsFunc.accept(map);
-        return new Metrics.MultiLineChart(chartId, () -> map);
+        return new MultiLineChart(chartId, () -> map);
     }
 
 }


### PR DESCRIPTION
This PR just cleans up some small things.

1. Updates the bStats Metrics class to the newest version.
2. Enables `minimizeJar` for `maven-shade-plugin` (reduces JAR size from 487KB to 450KB).
3. Adds to the message that is printed when Buscript fails to load.
4. Updates the VaultAPI repo (the one in our pom is no longer active).
5. Corrects a copy-paste error introduced in #2588.