### PR TITLE
Improve worldname checks

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
@@ -1,7 +1,5 @@
 package com.onarandombox.MultiverseCore;
 
-import java.util.Map;
-
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.api.MultiverseCoreConfig;
 import com.onarandombox.MultiverseCore.event.MVDebugModeEvent;
@@ -9,6 +7,8 @@ import me.main__.util.SerializationConfig.NoSuchPropertyException;
 import me.main__.util.SerializationConfig.Property;
 import me.main__.util.SerializationConfig.SerializationConfig;
 import org.bukkit.Bukkit;
+
+import java.util.Map;
 
 /**
  * Our configuration.
@@ -77,6 +77,8 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     private volatile boolean autopurge;
     @Property
     private volatile boolean idonotwanttodonate;
+    @Property
+    private volatile boolean allowunsafeworldname;
 
     public MultiverseCoreConfiguration() {
         super();
@@ -111,6 +113,7 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
         portalsearchradius = 128;
         autopurge = true;
         idonotwanttodonate = false;
+        allowunsafeworldname = false;
         // END CHECKSTYLE-SUPPRESSION: MagicNumberCheck
     }
 
@@ -381,5 +384,15 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Override
     public void setShowDonateMessage(boolean showDonateMessage) {
         this.idonotwanttodonate = !showDonateMessage;
+    }
+
+    @Override
+    public boolean isAllowUnsafeWorldName() {
+        return allowunsafeworldname;
+    }
+
+    @Override
+    public void setAllowUnsafeWorldName(boolean allowUnsafeWorldName) {
+        this.allowunsafeworldname = allowUnsafeWorldName;
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
@@ -239,4 +239,8 @@ public interface MultiverseCoreConfig extends ConfigurationSerializable {
      * @param idonotwanttodonate True if donation/patreon messages should be shown.
      */
     void setShowDonateMessage(boolean idonotwanttodonate);
+
+    boolean isAllowUnsafeWorldName();
+
+    void setAllowUnsafeWorldName(boolean allowUnsafeWorldName);
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -48,7 +48,6 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -130,7 +129,11 @@ public class WorldManager implements MVWorldManager {
         }
 
         // Check for valid world name
-        if (!(WorldNameChecker.isValidWorldName(oldName) && WorldNameChecker.isValidWorldName(newName))) {
+        if (!this.plugin.getMVConfig().isAllowUnsafeWorldName() && !WorldNameChecker.isValidWorldName(newName)) {
+            Logging.warning("Unable to clone world as world name '" + newName + "' is invalid.");
+            Logging.warning("World name should not contain spaces or special characters!");
+            Logging.warning("Enable allowunsafeworldname to bypass the check if you are absolutely sure this world is valid.");
+            Logging.warning("However, MV is not response of any damage to your world if you enable this option.");
             return false;
         }
 
@@ -234,13 +237,12 @@ public class WorldManager implements MVWorldManager {
     @Override
     public boolean addWorld(String name, Environment env, String seedString, WorldType type, Boolean generateStructures,
                             String generator, boolean useSpawnAdjust) {
-        if (name.equalsIgnoreCase("plugins") || name.equalsIgnoreCase("logs")) {
-            return false;
-        }
 
-        if (!WorldNameChecker.isValidWorldName(name)) {
-            Logging.warning("Invalid world name '" + name + "'");
+        if (!this.plugin.getMVConfig().isAllowUnsafeWorldName() && !WorldNameChecker.isValidWorldName(name)) {
+            Logging.warning("Unable to add world as world name '" + name + "' is invalid.");
             Logging.warning("World name should not contain spaces or special characters!");
+            Logging.warning("Enable allowunsafeworldname to bypass the check if you are absolutely sure this world is valid.");
+            Logging.warning("However, MV is not response of any damage to your world if you enable this option.");
             return false;
         }
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldNameChecker.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldNameChecker.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  */
 public class WorldNameChecker {
 
-    private static final Pattern WORLD_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9/._-]+");
+    private static final Pattern WORLD_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_-]+");
     private static final Set<String> BLACKLIST_NAMES = Collections.unmodifiableSet(new HashSet<String>() {{
         add("plugins");
         add("logs");

--- a/src/test/java/com/onarandombox/MultiverseCore/TestWorldStuff.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestWorldStuff.java
@@ -30,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Matchers;
 import org.mockito.internal.verification.VerificationModeFactory;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -38,8 +37,14 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 
-import static junit.framework.Assert.*;
-import static org.mockito.Mockito.*;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ PluginManager.class, MultiverseCore.class, Permission.class, Bukkit.class, WorldManager.class,
@@ -92,7 +97,7 @@ public class TestWorldStuff {
         // Import the first world. The world folder does not exist.
         plugin.onCommand(mockCommandSender, mockCommand, "", normalArgs);
         verify(mockCommandSender).sendMessage(ChatColor.RED + "FAILED.");
-        verify(mockCommandSender).sendMessage("That world folder does not exist. These look like worlds to me:");
+        verify(mockCommandSender).sendMessage(ChatColor.RED + "That world folder does not exist. These look like worlds to me:");
 
         // We should still have no worlds.
         assertEquals(0, creator.getCore().getMVWorldManager().getMVWorlds().size());


### PR DESCRIPTION
Adds config option to allow unsafe (e.g. / ) to be part of the world name. Those that know what they doing can use it for subdir worlds etc. Also, integrate the new world name restrictions from #2353 to WorldNameChecker to make things cleaner.