### PR TITLE
add portal intercept option

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -480,6 +480,11 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
             this.getMVConfig().setTeleportIntercept(this.multiverseConfig.getBoolean("teleportintercept"));
             this.multiverseConfig.set("teleportintercept", null);
         }
+        if (this.multiverseConfig.isSet("portalintercept")) {
+            Logging.config("Migrating 'portalintercept'...");
+            this.getMVConfig().setPortalIntercept(this.multiverseConfig.getBoolean("portalintercept"));
+            this.multiverseConfig.set("portalintercept", null);
+        }
         if (this.multiverseConfig.isSet("firstspawnoverride")) {
             Logging.config("Migrating 'firstspawnoverride'...");
             this.getMVConfig().setFirstSpawnOverride(this.multiverseConfig.getBoolean("firstspawnoverride"));

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
@@ -52,6 +52,8 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Property
     private volatile boolean teleportintercept;
     @Property
+    private volatile boolean portalintercept;
+    @Property
     private volatile boolean firstspawnoverride;
     @Property
     private volatile boolean displaypermerrors;
@@ -99,6 +101,7 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
         prefixchat = false;
         prefixchatformat = "[%world%]%chat%";
         teleportintercept = true;
+        portalintercept = true;
         firstspawnoverride = true;
         displaypermerrors = true;
         enablebuscript = true;
@@ -190,6 +193,22 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Override
     public void setTeleportIntercept(boolean teleportIntercept) {
         this.teleportintercept = teleportIntercept;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getPortalIntercept() {
+        return this.portalintercept;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPortalIntercept(boolean portalIntercept) {
+        this.portalintercept = portalIntercept;
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
@@ -123,6 +123,18 @@ public interface MultiverseCoreConfig extends ConfigurationSerializable {
     boolean getTeleportIntercept();
 
     /**
+     * Sets portalIntercept.
+     * @param portalIntercept The new value.
+     */
+    void setPortalIntercept(boolean portalIntercept);
+
+    /**
+     * Gets portalIntercept.
+     * @return portalIntercept.
+     */
+    boolean getPortalIntercept();
+
+    /**
      * Sets prefixChat.
      * @param prefixChat The new value.
      */

--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
@@ -300,7 +300,7 @@ public class MVPlayerListener implements Listener {
                     + "' because they don't have the FUNDS required to enter.");
             return;
         }
-        if (plugin.getMVConfig().getEnforceAccess()) {
+        if (plugin.getMVConfig().getEnforceAccess() && plugin.getMVConfig().getPortalIntercept()) {
             event.setCancelled(!pt.playerCanGoFromTo(fromWorld, toWorld, event.getPlayer(), event.getPlayer()));
             if (event.isCancelled()) {
                 Logging.fine("Player '" + event.getPlayer().getName()

--- a/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/listeners/MVPlayerListener.java
@@ -128,6 +128,7 @@ public class MVPlayerListener implements Listener {
         } else {
             Logging.finer("Player joined AGAIN!");
             if (this.plugin.getMVConfig().getEnforceAccess() // check this only if we're enforcing access!
+                    && (this.plugin.getMVConfig().getTeleportIntercept() && this.plugin.getMVConfig().getPortalIntercept()) // only all method Intercept will force send
                     && !this.plugin.getMVPerms().hasPermission(p, "multiverse.access." + p.getWorld().getName(), false)) {
                 p.sendMessage("[MV] - Sorry you can't be in this world anymore!");
                 this.sendPlayerToDefaultWorld(p);


### PR DESCRIPTION
I want players can:
1. use `/mvtp` to teleport between 2 or more normal world (`multiverse.access.XXX` & `enforceaccess: 'true'`)
2. use home plugin for teleport to any world (`teleportintercept: 'false'`)
3. for each normal world, vanilla nether portal for teleport to nether world, and end portal  for teleport to end world 

yet I can not figure out how to set that (only 1 & 2 works),
so I add a option for this.

permission & config I had used:
* `multiverse.access.world1`
* `multiverse.access.world2`
* `multiverse.teleport.self.w`
* `multiverse.teleport.self.b`
* `enforceaccess: 'true'`
* `teleportintercept: 'false'`
* `portalintercept: 'false'` (this PR)