### PR TITLE
Add PlaceholderAPI to softdepends

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: Multiverse-Core
 main: com.onarandombox.MultiverseCore.MultiverseCore
 authors: ['dumptruckman', 'Rigby', 'fernferret', 'lithium3141', 'main--']
 website: 'https://dev.bukkit.org/projects/multiverse-core'
-softdepend: ['Vault']
+softdepend: ['Vault', 'PlaceholderAPI']
 api-version: 1.13
 version: maven-version-number
 commands:


### PR DESCRIPTION
Should fix warnings such as `[PlaceholderAPI] Loaded class com.onarandombox.MultiverseCore.MultiverseCore from Multiverse-Core v4.3.0-b846 which is not a depend, softdepend or loadbefore of this plugin.`