### PR TITLE
Fix Tests on Java 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,24 +348,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>2.0.9</version>
-            <type>jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-            <version>2.0.9</version>
-            <type>jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>2.0.9</version>
-            <type>jar</type>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -352,12 +352,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>4.0.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -154,8 +154,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
                 <configuration>
-                    <parallel>methods</parallel>
-                    <threadCount>10</threadCount>
                     <excludes>
                         <exclude>**/TestCommandSender.java</exclude>
                         <exclude>**/TestInstanceCreator.java</exclude>

--- a/src/test/java/com/onarandombox/MultiverseCore/TestDebugMode.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestDebugMode.java
@@ -14,12 +14,9 @@ import org.bukkit.Server;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.java.JavaPluginLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.io.File;
 

--- a/src/test/java/com/onarandombox/MultiverseCore/TestDebugMode.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestDebugMode.java
@@ -20,9 +20,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 
@@ -31,9 +28,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ MultiverseCore.class, PluginDescriptionFile.class, JavaPluginLoader.class})
-@PowerMockIgnore("javax.script.*")
 public class TestDebugMode {
     TestInstanceCreator creator;
     Server mockServer;

--- a/src/test/java/com/onarandombox/MultiverseCore/TestEntitySpawnRules.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestEntitySpawnRules.java
@@ -20,9 +20,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -33,9 +30,6 @@ import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ MultiverseCore.class, PluginDescriptionFile.class, JavaPluginLoader.class})
-@PowerMockIgnore("javax.script.*")
 public class TestEntitySpawnRules {
     TestInstanceCreator creator;
     MultiverseCore core;

--- a/src/test/java/com/onarandombox/MultiverseCore/TestEntitySpawnRules.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestEntitySpawnRules.java
@@ -7,28 +7,28 @@ import com.onarandombox.MultiverseCore.utils.MockWorldFactory;
 import com.onarandombox.MultiverseCore.utils.TestInstanceCreator;
 import org.bukkit.World;
 import org.bukkit.WorldType;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Sheep;
 import org.bukkit.entity.Zombie;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.java.JavaPluginLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestEntitySpawnRules {
     TestInstanceCreator creator;
@@ -151,6 +151,6 @@ public class TestEntitySpawnRules {
         when(zombie.getType()).thenReturn(EntityType.ZOMBIE);
         when(zombie.getWorld()).thenReturn(this.cbworld);
 
-        when(cbworld.getEntities()).thenReturn(Arrays.asList((Entity) sheep, (Entity) zombie));
+        when(cbworld.getEntities()).thenReturn(Arrays.asList(sheep, zombie));
     }
 }

--- a/src/test/java/com/onarandombox/MultiverseCore/TestEntryFeeConversion.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestEntryFeeConversion.java
@@ -8,18 +8,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ MultiverseCore.class, PluginDescriptionFile.class, JavaPluginLoader.class})
-@PowerMockIgnore("javax.script.*")
 public class TestEntryFeeConversion {
 
     private TestInstanceCreator creator;

--- a/src/test/java/com/onarandombox/MultiverseCore/TestEntryFeeConversion.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestEntryFeeConversion.java
@@ -2,17 +2,16 @@ package com.onarandombox.MultiverseCore;
 
 import com.onarandombox.MultiverseCore.utils.TestInstanceCreator;
 import org.bukkit.Material;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.java.JavaPluginLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class TestEntryFeeConversion {
 

--- a/src/test/java/com/onarandombox/MultiverseCore/TestModifyCommand.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestModifyCommand.java
@@ -6,14 +6,13 @@ import org.bukkit.Server;
 import org.bukkit.World.Environment;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.java.JavaPluginLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/onarandombox/MultiverseCore/TestModifyCommand.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestModifyCommand.java
@@ -12,18 +12,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ MultiverseCore.class, PluginDescriptionFile.class, JavaPluginLoader.class })
-@PowerMockIgnore("javax.script.*")
 public class TestModifyCommand {
     TestInstanceCreator creator;
     Server mockServer;

--- a/src/test/java/com/onarandombox/MultiverseCore/TestWorldProperties.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestWorldProperties.java
@@ -45,10 +45,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.internal.verification.VerificationModeFactory;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 
@@ -57,12 +53,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ PluginManager.class, MultiverseCore.class, Permission.class, Bukkit.class,
-        WeatherChangeEvent.class, ThunderChangeEvent.class, AsyncPlayerChatEvent.class,
-        PlayerJoinEvent.class, PlayerRespawnEvent.class, EntityRegainHealthEvent.class,
-        FoodLevelChangeEvent.class, WorldManager.class, PluginDescriptionFile.class, JavaPluginLoader.class })
-@PowerMockIgnore("javax.script.*")
 public class TestWorldProperties {
     private TestInstanceCreator creator;
     private MultiverseCore core;
@@ -366,36 +356,36 @@ public class TestWorldProperties {
         when(mockPlayer.hasPlayedBefore()).thenReturn(true);
         when(mockPlayer.hasPermission("multiverse.access.world")).thenReturn(true);
         when(mockPlayer.getName()).thenReturn("MultiverseMan");
-        playerChatEvent = PowerMockito.mock(AsyncPlayerChatEvent.class);
+        playerChatEvent = mock(AsyncPlayerChatEvent.class);
         when(playerChatEvent.getPlayer()).thenReturn(mockPlayer);
         when(playerChatEvent.getFormat()).thenReturn("format");
         // player join
         mockNewPlayer = mock(Player.class);
         when(mockNewPlayer.hasPlayedBefore()).thenReturn(false);
-        playerJoinEvent = PowerMockito.mock(PlayerJoinEvent.class);
+        playerJoinEvent = mock(PlayerJoinEvent.class);
         when(playerJoinEvent.getPlayer()).thenReturn(mockPlayer);
-        playerNewJoinEvent = PowerMockito.mock(PlayerJoinEvent.class);
+        playerNewJoinEvent = mock(PlayerJoinEvent.class);
         when(playerNewJoinEvent.getPlayer()).thenReturn(mockNewPlayer);
         // player respawn
-        playerRespawnBed = PowerMockito.mock(PlayerRespawnEvent.class);
+        playerRespawnBed = mock(PlayerRespawnEvent.class);
         when(playerRespawnBed.getPlayer()).thenReturn(mockPlayer);
         when(playerRespawnBed.isBedSpawn()).thenReturn(true);
-        playerRespawnNormal = PowerMockito.mock(PlayerRespawnEvent.class);
+        playerRespawnNormal = mock(PlayerRespawnEvent.class);
         when(playerRespawnNormal.getPlayer()).thenReturn(mockPlayer);
         when(playerRespawnNormal.isBedSpawn()).thenReturn(false);
         //// Entity events
         mockHumanEntity = mock(HumanEntity.class);
         // entity regain health
-        entityRegainHealthEvent = PowerMockito.mock(EntityRegainHealthEvent.class);
+        entityRegainHealthEvent = mock(EntityRegainHealthEvent.class);
         when(entityRegainHealthEvent.getRegainReason()).thenReturn(RegainReason.REGEN);
         when(mockHumanEntity.getLocation()).thenReturn(new Location(world, 0, 0, 0));
         when(entityRegainHealthEvent.getEntity()).thenReturn(mockHumanEntity);
         // entity food level change event
-        entityFoodLevelChangeEvent = PowerMockito.mock(FoodLevelChangeEvent.class);
+        entityFoodLevelChangeEvent = mock(FoodLevelChangeEvent.class);
         // this won't do anything since we're not mocking a player,
         // but the plugin should be able to handle this!
         when(entityFoodLevelChangeEvent.getEntity()).thenReturn(mockHumanEntity);
-        entityFoodLevelRiseEvent = PowerMockito.mock(FoodLevelChangeEvent.class);
+        entityFoodLevelRiseEvent = mock(FoodLevelChangeEvent.class);
         when(mockPlayer.getFoodLevel()).thenReturn(2);
         when(entityFoodLevelRiseEvent.getEntity()).thenReturn(mockPlayer);
         when(entityFoodLevelRiseEvent.getFoodLevel()).thenReturn(3);

--- a/src/test/java/com/onarandombox/MultiverseCore/TestWorldProperties.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestWorldProperties.java
@@ -13,8 +13,6 @@ import com.onarandombox.MultiverseCore.configuration.SpawnLocation;
 import com.onarandombox.MultiverseCore.listeners.MVAsyncPlayerChatListener;
 import com.onarandombox.MultiverseCore.utils.MockWorldFactory;
 import com.onarandombox.MultiverseCore.utils.TestInstanceCreator;
-import com.onarandombox.MultiverseCore.utils.WorldManager;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Difficulty;
 import org.bukkit.GameMode;
@@ -36,22 +34,25 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.weather.ThunderChangeEvent;
 import org.bukkit.event.weather.WeatherChangeEvent;
-import org.bukkit.permissions.Permission;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.PluginManager;
-import org.bukkit.plugin.java.JavaPluginLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.internal.verification.VerificationModeFactory;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestWorldProperties {
     private TestInstanceCreator creator;
@@ -112,7 +113,7 @@ public class TestWorldProperties {
         String[] netherArgs = new String[] { "import", "world_nether", "nether" };
         core.onCommand(mockCommandSender, mockCommand, "", netherArgs);
         verify(mockCommandSender).sendMessage("Starting import of world 'world_nether'...");
-        verify(mockCommandSender, VerificationModeFactory.times(2)).sendMessage(
+        verify(mockCommandSender, times(2)).sendMessage(
                 ChatColor.GREEN + "Complete!");
 
         assertEquals(core.getServer().getWorlds().size(), 2);
@@ -212,7 +213,7 @@ public class TestWorldProperties {
         assertTrue(mvWorld.setColor("BLACK"));
         assertFalse(mvWorld.setColor("INVALID COLOR"));
         assertEquals(ChatColor.BLACK, mvWorld.getColor());
-        assertEquals(ChatColor.BLACK.toString() + "alias" + ChatColor.WHITE.toString(), mvWorld.getColoredWorldString());
+        assertEquals(ChatColor.BLACK + "alias" + ChatColor.WHITE, mvWorld.getColoredWorldString());
         mvWorld.setPVPMode(false);
         assertEquals(false, mvWorld.isPVPEnabled());
         assertTrue(mvWorld.setScaling(2D));
@@ -319,7 +320,7 @@ public class TestWorldProperties {
         assertEquals(true, mvWorld.isHidden());
         assertEquals("alias", mvWorld.getAlias());
         assertEquals(ChatColor.GREEN, mvWorld.getColor());
-        assertEquals(ChatColor.GREEN.toString() + "alias" + ChatColor.WHITE.toString(), mvWorld.getColoredWorldString());
+        assertEquals(ChatColor.GREEN + "alias" + ChatColor.WHITE, mvWorld.getColoredWorldString());
         assertEquals(false, mvWorld.isPVPEnabled());
         assertEquals(2D, mvWorld.getScaling(), 0);
         assertSame(worldManager.getMVWorld("world_nether").getCBWorld(),

--- a/src/test/java/com/onarandombox/MultiverseCore/TestWorldPurger.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestWorldPurger.java
@@ -14,18 +14,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ MultiverseCore.class, PluginDescriptionFile.class, JavaPluginLoader.class })
-@PowerMockIgnore("javax.script.*")
 public class TestWorldPurger {
     TestInstanceCreator creator;
     MultiverseCore core;

--- a/src/test/java/com/onarandombox/MultiverseCore/TestWorldPurger.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestWorldPurger.java
@@ -4,21 +4,20 @@ import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.api.WorldPurger;
 import com.onarandombox.MultiverseCore.utils.TestInstanceCreator;
 import org.bukkit.World;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Sheep;
 import org.bukkit.entity.Zombie;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.java.JavaPluginLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestWorldPurger {
     TestInstanceCreator creator;
@@ -115,6 +114,6 @@ public class TestWorldPurger {
         zombie = mock(Zombie.class);
         when(zombie.getType()).thenReturn(EntityType.ZOMBIE);
         when(zombie.getWorld()).thenReturn(world);
-        when(cbworld.getEntities()).thenReturn(Arrays.asList((Entity) sheep, (Entity) zombie));
+        when(cbworld.getEntities()).thenReturn(Arrays.asList(sheep, zombie));
     }
 }

--- a/src/test/java/com/onarandombox/MultiverseCore/TestWorldStuff.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestWorldStuff.java
@@ -32,19 +32,12 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Matchers;
 import org.mockito.internal.verification.VerificationModeFactory;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 
 import static junit.framework.Assert.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ PluginManager.class, MultiverseCore.class, Permission.class, Bukkit.class, WorldManager.class,
-        PluginDescriptionFile.class, JavaPluginLoader.class })
-@PowerMockIgnore("javax.script.*")
 public class TestWorldStuff {
 
     private TestInstanceCreator creator;

--- a/src/test/java/com/onarandombox/MultiverseCore/TestWorldStuff.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/TestWorldStuff.java
@@ -12,31 +12,29 @@ import com.onarandombox.MultiverseCore.exceptions.PropertyDoesNotExistException;
 import com.onarandombox.MultiverseCore.utils.MockWorldFactory;
 import com.onarandombox.MultiverseCore.utils.TestInstanceCreator;
 import com.onarandombox.MultiverseCore.utils.WorldCreatorMatcher;
-import com.onarandombox.MultiverseCore.utils.WorldManager;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Server;
 import org.bukkit.WorldCreator;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.permissions.Permission;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginDescriptionFile;
-import org.bukkit.plugin.PluginManager;
-import org.bukkit.plugin.java.JavaPluginLoader;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Matchers;
 import org.mockito.internal.verification.VerificationModeFactory;
 
 import java.io.File;
 
-import static junit.framework.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestWorldStuff {
 

--- a/src/test/java/com/onarandombox/MultiverseCore/utils/FileUtilsTest.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/utils/FileUtilsTest.java
@@ -1,7 +1,8 @@
 package com.onarandombox.MultiverseCore.utils;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -10,10 +11,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.dumptruckman.minecraft.util.Logging;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class FileUtilsTest {
 
@@ -137,7 +136,7 @@ public class FileUtilsTest {
         assertTrue(Files.isRegularFile(targetChildDirFile));
     }
 
-    @Test()
+    @Test
     public void copyFolder_intoExistingFolder_whereFileExists() throws Exception {
         Path targetDir = Files.createDirectory(tempDir.resolve("target"));
         Path targetFile = Files.createFile(targetDir.resolve("parentDirFile.txt"));

--- a/src/test/java/com/onarandombox/MultiverseCore/utils/MockWorldFactory.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/utils/MockWorldFactory.java
@@ -21,13 +21,17 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.WeakHashMap;
-import java.util.LinkedHashMap;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MockWorldFactory {
 

--- a/src/test/java/com/onarandombox/MultiverseCore/utils/TestInstanceCreator.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/utils/TestInstanceCreator.java
@@ -85,12 +85,6 @@ public class TestInstanceCreator {
                     "com.onarandombox.MultiverseCore.MultiverseCore"));
             when(pdf.getAuthors()).thenReturn(new ArrayList<String>());
             core = PowerMockito.spy(new MultiverseCore(mockPluginLoader, pdf, pluginDirectory, new File(pluginDirectory, "testPluginFile")));
-            PowerMockito.doAnswer(new Answer<Void>() {
-                @Override
-                public Void answer(InvocationOnMock invocation) throws Throwable {
-                    return null; // don't run metrics in tests
-                }
-            }).when(core, "setupMetrics");
 
             // Let's let all MV files go to bin/test
             doReturn(pluginDirectory).when(core).getDataFolder();

--- a/src/test/java/com/onarandombox/MultiverseCore/utils/TestInstanceCreator.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/utils/TestInstanceCreator.java
@@ -28,12 +28,9 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.mockito.ArgumentMatchers;
+import org.mockito.internal.util.reflection.ReflectionMemberAccessor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.easymock.PowerMock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.MockGateway;
-import org.powermock.reflect.Whitebox;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -52,6 +49,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.doAnswer;
 
 public class TestInstanceCreator {
@@ -69,22 +67,20 @@ public class TestInstanceCreator {
             pluginDirectory.mkdirs();
             assertTrue(pluginDirectory.exists());
 
-            MockGateway.MOCK_STANDARD_METHODS = false;
-
             // Initialize the Mock server.
             mockServer = mock(Server.class);
-            JavaPluginLoader mockPluginLoader = PowerMock.createMock(JavaPluginLoader.class);
-            Whitebox.setInternalState(mockPluginLoader, "server", mockServer);
+            JavaPluginLoader mockPluginLoader = mock(JavaPluginLoader.class);
+            new ReflectionMemberAccessor().set(JavaPluginLoader.class.getDeclaredField("server"), mockPluginLoader, mockServer);
             when(mockServer.getName()).thenReturn("TestBukkit");
             Logger.getLogger("Minecraft").setParent(Util.logger);
             when(mockServer.getLogger()).thenReturn(Util.logger);
             when(mockServer.getWorldContainer()).thenReturn(worldsDirectory);
 
             // Return a fake PDF file.
-            PluginDescriptionFile pdf = PowerMockito.spy(new PluginDescriptionFile("Multiverse-Core", "2.2-Test",
+            PluginDescriptionFile pdf = spy(new PluginDescriptionFile("Multiverse-Core", "2.2-Test",
                     "com.onarandombox.MultiverseCore.MultiverseCore"));
             when(pdf.getAuthors()).thenReturn(new ArrayList<String>());
-            core = PowerMockito.spy(new MultiverseCore(mockPluginLoader, pdf, pluginDirectory, new File(pluginDirectory, "testPluginFile")));
+            core = spy(new MultiverseCore(mockPluginLoader, pdf, pluginDirectory, new File(pluginDirectory, "testPluginFile")));
 
             // Let's let all MV files go to bin/test
             doReturn(pluginDirectory).when(core).getDataFolder();
@@ -97,7 +93,7 @@ public class TestInstanceCreator {
             JavaPlugin[] plugins = new JavaPlugin[] { core };
 
             // Mock the Plugin Manager
-            PluginManager mockPluginManager = PowerMockito.mock(PluginManager.class);
+            PluginManager mockPluginManager = mock(PluginManager.class);
             when(mockPluginManager.getPlugins()).thenReturn(plugins);
             when(mockPluginManager.getPlugin("Multiverse-Core")).thenReturn(core);
             when(mockPluginManager.getPermission(anyString())).thenReturn(null);
@@ -213,7 +209,7 @@ public class TestInstanceCreator {
             buscriptfield.setAccessible(true);
 
             try {
-                buscript = PowerMockito.spy(new Buscript(core));
+                buscript = spy(new Buscript(core));
                 when(buscript.getPlugin()).thenReturn(core);
             } catch (NullPointerException e) {
                 buscript = null;
@@ -222,25 +218,25 @@ public class TestInstanceCreator {
             buscriptfield.set(core, buscript);
 
             // Set worldManager
-            WorldManager wm = PowerMockito.spy(new WorldManager(core));
+            WorldManager wm = spy(new WorldManager(core));
             Field worldmanagerfield = MultiverseCore.class.getDeclaredField("worldManager");
             worldmanagerfield.setAccessible(true);
             worldmanagerfield.set(core, wm);
 
             // Set playerListener
-            MVPlayerListener pl = PowerMockito.spy(new MVPlayerListener(core));
+            MVPlayerListener pl = spy(new MVPlayerListener(core));
             Field playerlistenerfield = MultiverseCore.class.getDeclaredField("playerListener");
             playerlistenerfield.setAccessible(true);
             playerlistenerfield.set(core, pl);
 
             // Set entityListener
-            MVEntityListener el = PowerMockito.spy(new MVEntityListener(core));
+            MVEntityListener el = spy(new MVEntityListener(core));
             Field entitylistenerfield = MultiverseCore.class.getDeclaredField("entityListener");
             entitylistenerfield.setAccessible(true);
             entitylistenerfield.set(core, el);
 
             // Set weatherListener
-            MVWeatherListener wl = PowerMockito.spy(new MVWeatherListener(core));
+            MVWeatherListener wl = spy(new MVWeatherListener(core));
             Field weatherlistenerfield = MultiverseCore.class.getDeclaredField("weatherListener");
             weatherlistenerfield.setAccessible(true);
             weatherlistenerfield.set(core, wl);

--- a/src/test/java/com/onarandombox/MultiverseCore/utils/TestInstanceCreator.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/utils/TestInstanceCreator.java
@@ -27,7 +27,6 @@ import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.java.JavaPluginLoader;
 import org.bukkit.scheduler.BukkitScheduler;
-import org.mockito.ArgumentMatchers;
 import org.mockito.internal.util.reflection.ReflectionMemberAccessor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -41,16 +40,16 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 
 public class TestInstanceCreator {
     private MultiverseCore core;
@@ -147,7 +146,7 @@ public class TestInstanceCreator {
 
             when(mockServer.getPluginManager()).thenReturn(mockPluginManager);
 
-            when(mockServer.createWorld(ArgumentMatchers.isA(WorldCreator.class))).thenAnswer(
+            when(mockServer.createWorld(isA(WorldCreator.class))).thenAnswer(
                     new Answer<World>() {
                         @Override
                         public World answer(InvocationOnMock invocation) throws Throwable {
@@ -254,9 +253,9 @@ public class TestInstanceCreator {
             when(commandSender.getServer()).thenReturn(mockServer);
             when(commandSender.getName()).thenReturn("MockCommandSender");
             when(commandSender.isPermissionSet(anyString())).thenReturn(true);
-            when(commandSender.isPermissionSet(ArgumentMatchers.isA(Permission.class))).thenReturn(true);
+            when(commandSender.isPermissionSet(isA(Permission.class))).thenReturn(true);
             when(commandSender.hasPermission(anyString())).thenReturn(true);
-            when(commandSender.hasPermission(ArgumentMatchers.isA(Permission.class))).thenReturn(true);
+            when(commandSender.hasPermission(isA(Permission.class))).thenReturn(true);
             when(commandSender.addAttachment(core)).thenReturn(null);
             when(commandSender.isOp()).thenReturn(true);
 

--- a/src/test/java/com/onarandombox/MultiverseCore/utils/Util.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/utils/Util.java
@@ -10,8 +10,8 @@ package com.onarandombox.MultiverseCore.utils;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import java.util.logging.LogRecord;
 
 public class Util {
     private Util() {}

--- a/src/test/java/com/onarandombox/MultiverseCore/utils/WorldCreatorMatcher.java
+++ b/src/test/java/com/onarandombox/MultiverseCore/utils/WorldCreatorMatcher.java
@@ -11,7 +11,7 @@ import org.bukkit.WorldCreator;
 import org.mockito.ArgumentMatcher;
 
 public class WorldCreatorMatcher implements ArgumentMatcher<WorldCreator> {
-    private WorldCreator worldCreator;
+    private final WorldCreator worldCreator;
     private boolean careAboutSeeds = false;
     private boolean careAboutGenerators = false;
 

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This PR fixes tests on Java 16. It does so by removing PowerMock, as it turns out we don't need it anymore.

Mockito supports mocking final classes starting with version two, which I believe is what we were using PowerMock for. It's not enabled by default, but all you have to do to enable it is create a text file in the recourses folder with a specific string.

Other than that, I removed unneeded imports, and made the usage of `mock()` and `spy()` consistent (static imports in all the files).