### PR TITLE
Fix create command using "test" as the world name.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
@@ -114,7 +114,7 @@ public class CreateCommand extends MultiverseCommand {
                 // If there was only one arg specified, pad with another empty one.
                 genarray.add("");
             }
-            if (this.worldManager.getChunkGenerator(genarray.get(0), genarray.get(1), "test") == null) {
+            if (this.worldManager.getChunkGenerator(genarray.get(0), genarray.get(1), worldName) == null) {
                 // We have an invalid generator.
                 sender.sendMessage("Invalid generator! '" + generator + "'. " + ChatColor.RED + "Aborting world creation.");
                 return;


### PR DESCRIPTION
This is passing the world name to other plugin generators incorrectly and is causing issues. The plugin claims its not a bug with MVC, but it is in this case :P