### PR TITLE
Fix Bug Report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -20,7 +20,7 @@ body:
   - type: input
     id: mutliverse-version-info
     attributes:
-      label: `/mv version -p` output
+      label: '`/mv version -p` output'
       description: Run `/mv version -p` in the console, then copy and paste the link from the output of the command into this box.
     validations:
       required: true


### PR DESCRIPTION
This causes the Bug Report issue template to not even show up:

![image](https://user-images.githubusercontent.com/9273973/136495673-ec988bd1-643b-4e26-a4eb-47518662388c.png)
