### PR TITLE
Remove j.mp Domain from BitlyURLShortener

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/webpaste/BitlyURLShortener.java
@@ -27,7 +27,6 @@ class BitlyURLShortener extends URLShortener {
     @Override
     String encodeData(String data) {
         JSONObject json = new JSONObject();
-        json.put("domain", "j.mp");
         json.put("long_url", data);
         return json.toJSONString();
     }


### PR DESCRIPTION
This fixes the BitlyURLShortener. Seems Bitly no longer allows us to use the j.mp domain.