### PR TITLE
Bump notnull-instrumenter-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
             <plugin>
                 <groupId>se.eris</groupId>
                 <artifactId>notnull-instrumenter-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
This PR bumps the notnull-instrumenter-maven-plugin to the latest version, fixes compiling on Java 17.