### PR TITLE
Improve world regeneration command.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
@@ -7,6 +7,7 @@
 
 package com.onarandombox.MultiverseCore.api;
 
+import com.onarandombox.MultiverseCore.enums.KeepWorld;
 import com.onarandombox.MultiverseCore.utils.PurgeWorlds;
 import com.onarandombox.MultiverseCore.utils.SimpleWorldPurger;
 import org.bukkit.World;
@@ -108,11 +109,10 @@ public interface MVWorldManager {
      * @param name The name of the world to remove
      * @param removeFromConfig If true(default), we'll remove the entries from the
      *                         config. If false, they'll stay and the world may come back.
-     * @param deleteWorldFolder If true the world folder will be completely deleted. If false
-     *                          only the contents of the world folder will be deleted
+     * @param keepContents The files you want to keep. (Paper configuration, World directory, or nothing)
      * @return True if success, false if failure.
      */
-    boolean deleteWorld(String name, boolean removeFromConfig, boolean deleteWorldFolder);
+    boolean deleteWorld(String name, boolean removeFromConfig, KeepWorld keepContents);
 
     /**
      * Unload a world from Multiverse.

--- a/src/main/java/com/onarandombox/MultiverseCore/enums/KeepWorld.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/enums/KeepWorld.java
@@ -1,0 +1,19 @@
+package com.onarandombox.MultiverseCore.enums;
+
+/**
+ * Custom enum for method argument in deciding what to keep when deleting world files.
+ */
+public enum KeepWorld {
+    /**
+     * Keep paper's config file if it exists.
+     */
+    CONFIG,
+    /**
+     * Keeps the directory of the world folder, delete all the contents.
+     */
+    FOLDER,
+    /**
+     * Delete everything, including the directory.
+     */
+    NONE
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/FileUtils.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/FileUtils.java
@@ -68,6 +68,19 @@ public class FileUtils {
         }
     }
 
+    public static boolean deleteWorldContents(File file) {
+        try (Stream<Path> files = Files.walk(file.toPath())){
+            files.sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .filter(f -> !f.equals(file) && !f.getName().equals("paper-world.yml"))
+                    .forEach(File::delete);
+            return true;
+        } catch (IOException e) {
+            Logging.warning(e.getMessage());
+            return false;
+        }
+    }
+
     /**
      * Helper method to copy the world-folder.
      * @param source Source-File

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -16,6 +16,7 @@ import com.onarandombox.MultiverseCore.api.MVWorldManager;
 import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.api.SafeTTeleporter;
 import com.onarandombox.MultiverseCore.api.WorldPurger;
+import com.onarandombox.MultiverseCore.enums.KeepWorld;
 import com.onarandombox.MultiverseCore.event.MVWorldDeleteEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
@@ -505,7 +506,7 @@ public class WorldManager implements MVWorldManager {
      * {@inheritDoc}
      */
     @Override
-    public boolean deleteWorld(String name, boolean removeFromConfig, boolean deleteWorldFolder) {
+    public boolean deleteWorld(String name, boolean removeFromConfig, KeepWorld keepContents) {
         if (this.hasUnloadedWorld(name, false)) {
             // Attempt to load if unloaded so we can actually delete the world
             if (!this.doLoad(name)) {
@@ -540,7 +541,17 @@ public class WorldManager implements MVWorldManager {
         try {
             File worldFile = world.getWorldFolder();
             Logging.finer("deleteWorld(): worldFile: " + worldFile.getAbsolutePath());
-            if (deleteWorldFolder ? FileUtils.deleteFolder(worldFile) : FileUtils.deleteFolderContents(worldFile)) {
+            boolean success;
+
+            if (keepContents.equals(KeepWorld.FOLDER)) {
+                success = FileUtils.deleteFolderContents(worldFile);
+            } else if (keepContents.equals(KeepWorld.CONFIG)) {
+                success = FileUtils.deleteWorldContents(worldFile);
+            } else {
+                success = FileUtils.deleteFolder(worldFile);
+            }
+
+            if (success) {
                 Logging.info("World '%s' was DELETED.", name);
                 return true;
             } else {
@@ -564,7 +575,7 @@ public class WorldManager implements MVWorldManager {
      */
     @Override
     public boolean deleteWorld(String name, boolean removeFromConfig) {
-        return this.deleteWorld(name, removeFromConfig, true);
+        return this.deleteWorld(name, removeFromConfig, KeepWorld.NONE);
     }
 
     /**
@@ -947,7 +958,7 @@ public class WorldManager implements MVWorldManager {
         }
 
         // Do the regen.
-        if (!this.deleteWorld(name, false, false)) {
+        if (!this.deleteWorld(name, false, KeepWorld.CONFIG)) {
             Logging.severe("Unable to regen world as world cannot be deleted.");
             return false;
         }

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -971,6 +971,11 @@ public class WorldManager implements MVWorldManager {
             }
         }
 
+        // If using a new seed, you will most definitely want the same spawn the world uses.
+        if (useNewSeed && !world.getSpawnLocation().equals(world.getCBWorld().getSpawnLocation())) {
+            world.setSpawnLocation(world.getCBWorld().getSpawnLocation());
+        }
+
         // Send all players that were in the old world, BACK to it!
         SafeTTeleporter teleporter = this.plugin.getSafeTTeleporter();
         Location newSpawn = world.getSpawnLocation();


### PR DESCRIPTION
Fixes #2783, also fixes an unwanted behaviour where the spawn on regenerated worlds stays the same when providing a new seed.

When fixing #2783, I don't know if I'm allowed to modify the classes in the API package. If this shouldn't happen, we could always make the `deleteWorldFolder` boolean to keep the paper config instead of deleting all files in the directory.