### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
     - name: Set up JDK 8
       uses: actions/setup-java@v3.9.0 #https://github.com/actions/setup-java/releases
       with:
-        java-version: 1.8
+        distribution: 'temurin'
+        java-version: 8
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Maven CI/CD
 
 on:
   push:
-    branches: [ main, update-actions ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.3.0 #https://github.com/actions/checkout/releases
     - name: Set up JDK 8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3.9.0 #https://github.com/actions/setup-java/releases
       with:
         java-version: 1.8
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Maven CI/CD
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, update-actions ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Update Actions to get rid of deprecation warnings
Also added links to their release pages as a comment to easily find their latest version in the future
![image](https://user-images.githubusercontent.com/65610536/216419100-cfe66125-3f28-4001-bc51-78c7f1caa002.png)

Builds successfully without the warnings. [My Test Build](https://github.com/Chris6ix/Multiverse-Core/actions/runs/4077431786).
