### PR TITLE
feat: Implement create, delete, clone, regen, load and unload

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -25,12 +25,18 @@ import com.onarandombox.MultiverseCore.api.LocationManipulation;
 import com.onarandombox.MultiverseCore.api.MVConfig;
 import com.onarandombox.MultiverseCore.api.MVCore;
 import com.onarandombox.MultiverseCore.api.MVWorld;
-import com.onarandombox.MultiverseCore.api.WorldManager;
 import com.onarandombox.MultiverseCore.api.SafeTTeleporter;
+import com.onarandombox.MultiverseCore.api.WorldManager;
 import com.onarandombox.MultiverseCore.commands.CheckCommand;
+import com.onarandombox.MultiverseCore.commands.CloneCommand;
+import com.onarandombox.MultiverseCore.commands.ConfirmCommand;
 import com.onarandombox.MultiverseCore.commands.CreateCommand;
 import com.onarandombox.MultiverseCore.commands.DebugCommand;
+import com.onarandombox.MultiverseCore.commands.DeleteCommand;
+import com.onarandombox.MultiverseCore.commands.LoadCommand;
+import com.onarandombox.MultiverseCore.commands.RegenCommand;
 import com.onarandombox.MultiverseCore.commands.TeleportCommand;
+import com.onarandombox.MultiverseCore.commands.UnloadCommand;
 import com.onarandombox.MultiverseCore.commandtools.MVCommandManager;
 import com.onarandombox.MultiverseCore.destination.DestinationsProvider;
 import com.onarandombox.MultiverseCore.destination.core.AnchorDestination;
@@ -195,9 +201,15 @@ public class MultiverseCore extends JavaPlugin implements MVCore {
     private void registerCommands() {
         this.commandManager = new MVCommandManager(this);
         this.commandManager.registerCommand(new CheckCommand(this));
+        this.commandManager.registerCommand(new CloneCommand(this));
+        this.commandManager.registerCommand(new ConfirmCommand(this));
         this.commandManager.registerCommand(new CreateCommand(this));
         this.commandManager.registerCommand(new DebugCommand(this));
+        this.commandManager.registerCommand(new DeleteCommand(this));
+        this.commandManager.registerCommand(new LoadCommand(this));
+        this.commandManager.registerCommand(new RegenCommand(this));
         this.commandManager.registerCommand(new TeleportCommand(this));
+        this.commandManager.registerCommand(new UnloadCommand(this));
     }
 
     /**

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CheckCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CheckCommand.java
@@ -1,6 +1,6 @@
 package com.onarandombox.MultiverseCore.commands;
 
-import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.BukkitCommandIssuer;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
@@ -23,7 +23,7 @@ public class CheckCommand extends MultiverseCommand {
     @CommandCompletion("@players @destinations|@mvworlds")
     @Syntax("<player> <destination>")
     @Description("Checks if a player can teleport to a destination.")
-    public void onCheckCommand(CommandIssuer issuer,
+    public void onCheckCommand(BukkitCommandIssuer issuer,
 
                                @Syntax("<player>")
                                @Description("Player to check destination on.")

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
@@ -10,7 +10,6 @@ import co.aikar.commands.annotation.Single;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
-import com.onarandombox.MultiverseCore.api.MVWorld;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,25 +21,25 @@ public class CloneCommand extends MultiverseCommand {
 
     @Subcommand("clone")
     @CommandPermission("multiverse.core.clone")
-    @Syntax("<world> <new world name>")
     @CommandCompletion("@mvworlds:scope=both @empty")
+    @Syntax("<world> <new world name>")
     @Description("Clones a world.")
     public void onCloneCommand(CommandIssuer issuer,
 
-                               @NotNull
+                               @Conditions("worldname:scope=both")
                                @Syntax("<world>")
                                @Description("The target world to clone.")
-                               MVWorld world,
+                               String worldName,
 
                                @Single
                                @Conditions("worldname:scope=new")
-                               @Syntax("<name>")
+                               @Syntax("<new world name>")
                                @Description("The new cloned world name.")
                                String newWorldName
     ) {
-        issuer.sendMessage(String.format("Cloning world '%s' to '%s'...", world.getName(), newWorldName));
+        issuer.sendMessage(String.format("Cloning world '%s' to '%s'...", worldName, newWorldName));
 
-        if (!this.plugin.getMVWorldManager().cloneWorld(world.getName(), newWorldName)) {
+        if (!this.plugin.getMVWorldManager().cloneWorld(worldName, newWorldName)) {
             issuer.sendMessage(String.format("%sWorld could not be cloned! See console for more details.", ChatColor.RED));
             return;
         }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
@@ -1,0 +1,49 @@
+package com.onarandombox.MultiverseCore.commands;
+
+import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Conditions;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Single;
+import co.aikar.commands.annotation.Subcommand;
+import co.aikar.commands.annotation.Syntax;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MVWorld;
+import org.bukkit.ChatColor;
+import org.jetbrains.annotations.NotNull;
+
+@CommandAlias("mv")
+public class CloneCommand extends MultiverseCommand {
+    public CloneCommand(@NotNull MultiverseCore plugin) {
+        super(plugin);
+    }
+
+    @Subcommand("clone")
+    @CommandPermission("multiverse.core.clone")
+    @Syntax("<world> <new-world-name>")
+    @CommandCompletion("@mvworlds:type=includeunloaded @empty")
+    @Description("Clones a world.")
+    public void onCloneCommand(CommandIssuer issuer,
+
+                               @NotNull
+                               @Syntax("<world>")
+                               @Description("Current multiverse world.")
+                               MVWorld world,
+
+                               @Single
+                               @Conditions("worldname:type=new")
+                               @Syntax("<name>")
+                               @Description("New cloned world name.")
+                               String newWorldName
+    ) {
+        issuer.sendMessage(String.format("Cloning world '%s' to '%s'...", world.getName(), newWorldName));
+
+        if (!this.plugin.getMVWorldManager().cloneWorld(world.getName(), newWorldName)) {
+            issuer.sendMessage(String.format("%sWorld could not be cloned! See console for more details.", ChatColor.RED));
+            return;
+        }
+        issuer.sendMessage(String.format("%sWorld cloned!", ChatColor.GREEN));
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
@@ -22,20 +22,20 @@ public class CloneCommand extends MultiverseCommand {
 
     @Subcommand("clone")
     @CommandPermission("multiverse.core.clone")
-    @Syntax("<world> <new-world-name>")
-    @CommandCompletion("@mvworlds:type=includeunloaded @empty")
+    @Syntax("<world> <new world name>")
+    @CommandCompletion("@mvworlds:scope=both @empty")
     @Description("Clones a world.")
     public void onCloneCommand(CommandIssuer issuer,
 
                                @NotNull
                                @Syntax("<world>")
-                               @Description("Current multiverse world.")
+                               @Description("The target world to clone.")
                                MVWorld world,
 
                                @Single
-                               @Conditions("worldname:type=new")
+                               @Conditions("worldname:scope=new")
                                @Syntax("<name>")
-                               @Description("New cloned world name.")
+                               @Description("The new cloned world name.")
                                String newWorldName
     ) {
         issuer.sendMessage(String.format("Cloning world '%s' to '%s'...", world.getName(), newWorldName));
@@ -44,6 +44,6 @@ public class CloneCommand extends MultiverseCommand {
             issuer.sendMessage(String.format("%sWorld could not be cloned! See console for more details.", ChatColor.RED));
             return;
         }
-        issuer.sendMessage(String.format("%sWorld cloned!", ChatColor.GREEN));
+        issuer.sendMessage(String.format("%sCloned world '%s'!", ChatColor.GREEN, newWorldName));
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ConfirmCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ConfirmCommand.java
@@ -1,0 +1,23 @@
+package com.onarandombox.MultiverseCore.commands;
+
+import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Subcommand;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import org.jetbrains.annotations.NotNull;
+
+@CommandAlias("mv")
+public class ConfirmCommand extends MultiverseCommand {
+    public ConfirmCommand(@NotNull MultiverseCore plugin) {
+        super(plugin);
+    }
+
+    @Subcommand("confirm")
+    @CommandPermission("multiverse.core.confirm")
+    @Description("Confirms dangerous commands before executing them.")
+    public void onConfirmCommand(@NotNull BukkitCommandIssuer issuer) {
+        this.plugin.getCommandManager().getCommandQueueManager().runQueuedCommand(issuer.getIssuer());
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
@@ -84,7 +84,7 @@ public class CreateCommand extends MultiverseCommand {
     @Description("Creates a new world and loads it.")
     public void onCreateCommand(BukkitCommandIssuer issuer,
 
-                                @Conditions("worldname:type=new")
+                                @Conditions("worldname:scope=new")
                                 @Syntax("<name>")
                                 @Description("New world name.")
                                 String worldName,

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
@@ -105,7 +105,7 @@ public class CreateCommand extends MultiverseCommand {
         issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_SEED, "{seed}", parsedFlags.flagValue("--seed", "RANDOM", String.class));
         issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_WORLDTYPE, "{worldType}", parsedFlags.flagValue("--world-type", WorldType.NORMAL, WorldType.class).name());
         issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_ADJUSTSPAWN, "{adjustSpawn}", String.valueOf(parsedFlags.hasFlag("--adjust-spawn")));
-        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_GENERATOR, "{generator}", parsedFlags.flagValue("--generator", String.class));
+        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_GENERATOR, "{generator}", parsedFlags.flagValue("--generator", "null", String.class));
         issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_STRUCTURES, "{structures}", String.valueOf(!parsedFlags.hasFlag("--no-structures")));
 
         issuer.sendInfo(MVCorei18n.CREATE_LOADING);

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
@@ -8,6 +8,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 
 import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.InvalidCommandArgument;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
@@ -21,11 +22,10 @@ import com.onarandombox.MultiverseCore.commandtools.flags.CommandFlag;
 import com.onarandombox.MultiverseCore.commandtools.flags.CommandFlagGroup;
 import com.onarandombox.MultiverseCore.commandtools.flags.CommandValueFlag;
 import com.onarandombox.MultiverseCore.commandtools.flags.ParsedCommandFlags;
+import com.onarandombox.MultiverseCore.locale.MVCorei18n;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.WorldType;
-import org.bukkit.command.CommandException;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
@@ -57,7 +57,7 @@ public class CreateCommand extends MultiverseCommand {
                             try {
                                 return WorldType.valueOf(value.toUpperCase());
                             } catch (IllegalArgumentException e) {
-                                throw new CommandException("Invalid world type: " + value);
+                                throw new InvalidCommandArgument("Invalid world type: " + value);
                             }
                         })
                         .completion(() -> {
@@ -80,35 +80,35 @@ public class CreateCommand extends MultiverseCommand {
     @Subcommand("create")
     @CommandPermission("multiverse.core.create")
     @CommandCompletion("@empty  @flags:groupName=mvcreate")
-    @Syntax("<name> <env> --seed [seed] --generator [generator[:id]] --world-type [worldtype] --adjust-spawn --no-structures")
-    @Description("Creates a new world and loads it.")
+    @Syntax("<name> <environment> --seed [seed] --generator [generator[:id]] --world-type [worldtype] --adjust-spawn --no-structures")
+    @Description("{@@mv-core.create_description}")
     public void onCreateCommand(BukkitCommandIssuer issuer,
 
                                 @Conditions("worldname:scope=new")
                                 @Syntax("<name>")
-                                @Description("New world name.")
+                                @Description("{@@mv-core.create_name_description}")
                                 String worldName,
 
-                                @Syntax("<env>")
-                                @Description("The world's environment. See: /mv env")
+                                @Syntax("<environment>")
+                                @Description("{@@mv-core.create_environment_description}")
                                 World.Environment environment,
 
                                 @Optional
                                 @Syntax("--seed [seed] --generator [generator[:id]] --world-type [worldtype] --adjust-spawn --no-structures")
-                                @Description("Additional world settings. See http://gg.gg/nn8bl for all possible flags.")
+                                @Description("{@@mv-core.create_flags_description}")
                                 String[] flags
     ) {
         ParsedCommandFlags parsedFlags = parseFlags(flags);
 
-        issuer.sendMessage("Creating world " + worldName + " with the following properties:");
-        issuer.sendMessage("Environment: " + environment.name());
-        issuer.sendMessage("Seed: " + parsedFlags.flagValue("--seed", "RANDOM", String.class));
-        issuer.sendMessage("World Type: " + parsedFlags.flagValue("--world-type", WorldType.NORMAL, WorldType.class).name());
-        issuer.sendMessage("Adjust Spawn: " + parsedFlags.hasFlag("--adjust-spawn"));
-        issuer.sendMessage("Generator: " + parsedFlags.flagValue("--generator", String.class));
-        issuer.sendMessage("Structures: " + !parsedFlags.hasFlag("--no-structures"));
+        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES, "{worldName}", worldName);
+        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_ENVIRONMENT, "{environment}", environment.name());
+        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_SEED, "{seed}", parsedFlags.flagValue("--seed", "RANDOM", String.class));
+        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_WORLDTYPE, "{worldType}", parsedFlags.flagValue("--world-type", WorldType.NORMAL, WorldType.class).name());
+        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_ADJUSTSPAWN, "{adjustSpawn}", String.valueOf(parsedFlags.hasFlag("--adjust-spawn")));
+        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_GENERATOR, "{generator}", parsedFlags.flagValue("--generator", String.class));
+        issuer.sendInfo(MVCorei18n.CREATE_PROPERTIES_STRUCTURES, "{structures}", String.valueOf(!parsedFlags.hasFlag("--no-structures")));
 
-        issuer.sendMessage(ChatColor.ITALIC + "Creating world...");
+        issuer.sendInfo(MVCorei18n.CREATE_LOADING);
 
         if (!worldManager.addWorld(
                 worldName,
@@ -119,9 +119,9 @@ public class CreateCommand extends MultiverseCommand {
                 parsedFlags.flagValue("--generator", String.class),
                 parsedFlags.hasFlag("--no-structures")
         )) {
-            issuer.sendMessage("World creation failed! See console for details.");
+            issuer.sendError(MVCorei18n.CREATE_FAILED, "{worldName}", worldName);
             return;
         }
-        issuer.sendMessage("World " + worldName + " created successfully!");
+        issuer.sendInfo(MVCorei18n.CREATE_SUCCESS, "{worldName}", worldName);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DebugCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DebugCommand.java
@@ -4,7 +4,6 @@ import co.aikar.commands.BukkitCommandIssuer;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
-import co.aikar.commands.annotation.Conditions;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
@@ -33,7 +32,6 @@ public class DebugCommand extends MultiverseCommand {
     @Description("{@@mv-core.debug_change_description}")
     public void onChangeDebugCommand(BukkitCommandIssuer issuer,
 
-                                     @Conditions("debuglevel")
                                      @Syntax("<{@@mv-core.debug_change_syntax}>")
                                      @Description("{@@mv-core.debug_change_level_description}")
                                      int level) {

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DebugCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DebugCommand.java
@@ -27,8 +27,8 @@ public class DebugCommand extends MultiverseCommand {
 
     @Subcommand("debug")
     @CommandPermission("multiverse.core.debug")
-    @Syntax("<{@@mv-core.debug_change_syntax}>")
     @CommandCompletion("@range:3")
+    @Syntax("<{@@mv-core.debug_change_syntax}>")
     @Description("{@@mv-core.debug_change_description}")
     public void onChangeDebugCommand(BukkitCommandIssuer issuer,
 

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DebugCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DebugCommand.java
@@ -1,6 +1,6 @@
 package com.onarandombox.MultiverseCore.commands;
 
-import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.BukkitCommandIssuer;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.NotNull;
 
 @CommandAlias("mv")
 public class DebugCommand extends MultiverseCommand {
-
     public DebugCommand(@NotNull MultiverseCore plugin) {
         super(plugin);
     }
@@ -23,7 +22,7 @@ public class DebugCommand extends MultiverseCommand {
     @Subcommand("debug")
     @CommandPermission("multiverse.core.debug")
     @Description("{@@mv-core.debug_info_description}")
-    public void onShowDebugCommand(@NotNull CommandIssuer issuer) {
+    public void onShowDebugCommand(BukkitCommandIssuer issuer) {
         this.displayDebugMode(issuer);
     }
 
@@ -32,7 +31,7 @@ public class DebugCommand extends MultiverseCommand {
     @Syntax("<{@@mv-core.debug_change_syntax}>")
     @CommandCompletion("@range:3")
     @Description("{@@mv-core.debug_change_description}")
-    public void onChangeDebugCommand(@NotNull CommandIssuer issuer,
+    public void onChangeDebugCommand(BukkitCommandIssuer issuer,
 
                                      @Conditions("debuglevel")
                                      @Syntax("<{@@mv-core.debug_change_syntax}>")
@@ -44,7 +43,7 @@ public class DebugCommand extends MultiverseCommand {
         this.displayDebugMode(issuer);
     }
 
-    private void displayDebugMode(@NotNull CommandIssuer issuer) {
+    private void displayDebugMode(BukkitCommandIssuer issuer) {
         final int debugLevel = this.plugin.getMVConfig().getGlobalDebug();
         if (debugLevel == 0) {
             issuer.sendInfo(MVCorei18n.DEBUG_INFO_OFF);

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
@@ -22,8 +22,8 @@ public class DeleteCommand extends MultiverseCommand {
 
     @Subcommand("delete")
     @CommandPermission("multiverse.core.delete")
-    @Syntax("<world>")
     @CommandCompletion("@mvworlds:scope=both")
+    @Syntax("<world>")
     @Description("Deletes a world on your server PERMANENTLY.")
     public void onDeleteCommand(BukkitCommandIssuer issuer,
 

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
@@ -1,0 +1,49 @@
+package com.onarandombox.MultiverseCore.commands;
+
+import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Conditions;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Single;
+import co.aikar.commands.annotation.Subcommand;
+import co.aikar.commands.annotation.Syntax;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.commandtools.queue.QueuedCommand;
+import org.bukkit.ChatColor;
+import org.jetbrains.annotations.NotNull;
+
+@CommandAlias("mv")
+public class DeleteCommand extends MultiverseCommand {
+    public DeleteCommand(@NotNull MultiverseCore plugin) {
+        super(plugin);
+    }
+
+    @Subcommand("delete")
+    @CommandPermission("multiverse.core.delete")
+    @Syntax("<world>")
+    @CommandCompletion("@mvworlds:type=includeunloaded")
+    @Description("Deletes a world on your server PERMANENTLY.")
+    public void onDeleteCommand(BukkitCommandIssuer issuer,
+
+                                @Single
+                                @Conditions("worldname:type=includeunloaded")
+                                @Syntax("<world>")
+                                @Description("Multiverse world you want to delete.")
+                                String worldName
+    ) {
+        this.plugin.getCommandManager().getCommandQueueManager().addToQueue(new QueuedCommand(
+                issuer.getIssuer(),
+                () -> {
+                    issuer.sendMessage(String.format("Deleting world '%s'...", worldName));
+                    if (!this.plugin.getMVWorldManager().deleteWorld(worldName)) {
+                        issuer.sendMessage(String.format("%sThere was an issue deleting '%s'! Please check console for errors.", ChatColor.RED, worldName));
+                        return;
+                    }
+                    issuer.sendMessage(String.format("%sWorld %s was deleted!", ChatColor.GREEN, worldName));
+                },
+                "Are you sure you want to delete world '" + worldName + "'?"
+        ));
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
@@ -23,14 +23,14 @@ public class DeleteCommand extends MultiverseCommand {
     @Subcommand("delete")
     @CommandPermission("multiverse.core.delete")
     @Syntax("<world>")
-    @CommandCompletion("@mvworlds:type=includeunloaded")
+    @CommandCompletion("@mvworlds:scope=both")
     @Description("Deletes a world on your server PERMANENTLY.")
     public void onDeleteCommand(BukkitCommandIssuer issuer,
 
                                 @Single
-                                @Conditions("worldname:type=includeunloaded")
+                                @Conditions("worldname:scope=both")
                                 @Syntax("<world>")
-                                @Description("Multiverse world you want to delete.")
+                                @Description("The world you want to delete.")
                                 String worldName
     ) {
         this.plugin.getCommandManager().getCommandQueueManager().addToQueue(new QueuedCommand(

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/LoadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/LoadCommand.java
@@ -1,0 +1,42 @@
+package com.onarandombox.MultiverseCore.commands;
+
+import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Conditions;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Single;
+import co.aikar.commands.annotation.Subcommand;
+import co.aikar.commands.annotation.Syntax;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import org.jetbrains.annotations.NotNull;
+
+@CommandAlias("mv")
+public class LoadCommand extends MultiverseCommand {
+    public LoadCommand(@NotNull MultiverseCore plugin) {
+        super(plugin);
+    }
+
+    @Subcommand("load")
+    @CommandPermission("multiverse.core.load")
+    @CommandCompletion("@mvworlds:type=unloaded")
+    @Syntax("<world>")
+    @Description("Loads a world. World must be already in worlds.yml, else please use /mv import.")
+    public void onLoadCommand(BukkitCommandIssuer issuer,
+
+                              @Single
+                              @Conditions("worldname:type=unloaded")
+                              @Syntax("<world>")
+                              @Description("Name of world you want to load.")
+                              String worldName
+    ) {
+        issuer.sendMessage(String.format("Loading world '%s'...", worldName));
+
+        if (!this.plugin.getMVWorldManager().loadWorld(worldName)) {
+            issuer.sendMessage(String.format("Error trying to load world '%s'!", worldName));
+            return;
+        }
+        issuer.sendMessage(String.format("Loaded world '%s'!", worldName));
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/LoadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/LoadCommand.java
@@ -20,13 +20,13 @@ public class LoadCommand extends MultiverseCommand {
 
     @Subcommand("load")
     @CommandPermission("multiverse.core.load")
-    @CommandCompletion("@mvworlds:type=unloaded")
+    @CommandCompletion("@mvworlds:scope=unloaded")
     @Syntax("<world>")
     @Description("Loads a world. World must be already in worlds.yml, else please use /mv import.")
     public void onLoadCommand(BukkitCommandIssuer issuer,
 
                               @Single
-                              @Conditions("worldname:type=unloaded")
+                              @Conditions("worldname:scope=unloaded")
                               @Syntax("<world>")
                               @Description("Name of world you want to load.")
                               String worldName

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/MultiverseCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/MultiverseCommand.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
  * A base command for Multiverse.
  */
 public class MultiverseCommand extends BaseCommand {
-
     protected final MultiverseCore plugin;
     protected final WorldManager worldManager;
     protected final CommandFlagsManager flagsManager;

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
@@ -1,0 +1,79 @@
+package com.onarandombox.MultiverseCore.commands;
+
+import java.util.Collections;
+import java.util.Random;
+
+import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Conditions;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Optional;
+import co.aikar.commands.annotation.Subcommand;
+import co.aikar.commands.annotation.Syntax;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.commandtools.flags.CommandFlag;
+import com.onarandombox.MultiverseCore.commandtools.flags.CommandFlagGroup;
+import com.onarandombox.MultiverseCore.commandtools.flags.CommandValueFlag;
+import com.onarandombox.MultiverseCore.commandtools.flags.ParsedCommandFlags;
+import com.onarandombox.MultiverseCore.commandtools.queue.QueuedCommand;
+import org.bukkit.ChatColor;
+import org.jetbrains.annotations.NotNull;
+
+@CommandAlias("mv")
+public class RegenCommand extends MultiverseCommand {
+    public RegenCommand(@NotNull MultiverseCore plugin) {
+        super(plugin);
+
+        registerFlagGroup(CommandFlagGroup.builder("mvregen")
+                .add(CommandValueFlag.builder("--seed", String.class)
+                        .addAlias("-s")
+                        .completion(() -> Collections.singleton(String.valueOf(new Random().nextLong())))
+                        .optional()
+                        .build())
+                .add(CommandFlag.builder("--keep-gamerules")
+                        .addAlias("-k")
+                        .build())
+                .build());
+    }
+
+    @Subcommand("regen")
+    @CommandPermission("multiverse.core.regen")
+    @Syntax("<world> --seed [seed] --keep-gamerules")
+    @CommandCompletion("@mvworlds:type=includeunloaded @flags:groupName=mvregen")
+    @Description("Regenerates a world on your server. The previous state will be lost PERMANENTLY.")
+    public void onRegenCommand(BukkitCommandIssuer issuer,
+
+                               @Conditions("worldname:type=includeunloaded")
+                               @Syntax("<world>")
+                               @Description("World that you want to regen.")
+                               String worldName,
+
+                               @Optional
+                               @Syntax("--seed [seed] --keep-gamerules")
+                               @Description("Other world settings. See: http://gg.gg/nn8lk")
+                               String[] flags
+    ) {
+        ParsedCommandFlags parsedFlags = parseFlags(flags);
+
+        this.plugin.getCommandManager().getCommandQueueManager().addToQueue(new QueuedCommand(
+                issuer.getIssuer(),
+                () -> {
+                    issuer.sendMessage(String.format("Regenerating world '%s'...", worldName));
+                    if (!this.plugin.getMVWorldManager().regenWorld(
+                            worldName,
+                            parsedFlags.hasFlag("--seed"),
+                            parsedFlags.hasFlagValue("--seed"),
+                            parsedFlags.flagValue("--seed", String.class),
+                            parsedFlags.hasFlag("--keep-gamerules")
+                    )) {
+                        issuer.sendMessage(String.format("%sThere was an issue regenerating '%s'! Please check console for errors.", ChatColor.RED, worldName));
+                        return;
+                    }
+                    issuer.sendMessage(String.format("%sWorld %s was regenerated!", ChatColor.GREEN, worldName));
+                },
+                "Are you sure you want to regenerate world '" + worldName + "'?"
+        ));
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
@@ -40,8 +40,8 @@ public class RegenCommand extends MultiverseCommand {
 
     @Subcommand("regen")
     @CommandPermission("multiverse.core.regen")
-    @Syntax("<world> --seed [seed] --keep-gamerules")
     @CommandCompletion("@mvworlds:type=includeunloaded @flags:groupName=mvregen")
+    @Syntax("<world> --seed [seed] --keep-gamerules")
     @Description("Regenerates a world on your server. The previous state will be lost PERMANENTLY.")
     public void onRegenCommand(BukkitCommandIssuer issuer,
 

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
@@ -40,12 +40,12 @@ public class RegenCommand extends MultiverseCommand {
 
     @Subcommand("regen")
     @CommandPermission("multiverse.core.regen")
-    @CommandCompletion("@mvworlds:type=includeunloaded @flags:groupName=mvregen")
+    @CommandCompletion("@mvworlds:scope=both @flags:groupName=mvregen")
     @Syntax("<world> --seed [seed] --keep-gamerules")
     @Description("Regenerates a world on your server. The previous state will be lost PERMANENTLY.")
     public void onRegenCommand(BukkitCommandIssuer issuer,
 
-                               @Conditions("worldname:type=includeunloaded")
+                               @Conditions("worldname:scope=both")
                                @Syntax("<world>")
                                @Description("World that you want to regen.")
                                String worldName,
@@ -64,7 +64,7 @@ public class RegenCommand extends MultiverseCommand {
                     if (!this.plugin.getMVWorldManager().regenWorld(
                             worldName,
                             parsedFlags.hasFlag("--seed"),
-                            parsedFlags.hasFlagValue("--seed"),
+                            !parsedFlags.hasFlagValue("--seed"),
                             parsedFlags.flagValue("--seed", String.class),
                             parsedFlags.hasFlag("--keep-gamerules")
                     )) {

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
@@ -19,8 +19,8 @@ public class TeleportCommand extends MultiverseCommand {
     }
 
     @Subcommand("teleport|tp")
-    @Syntax("[player] <destination>")
     @CommandCompletion("@players|@mvworlds:playerOnly|@destinations:playerOnly @mvworlds|@destinations")
+    @Syntax("[player] <destination>")
     @Description("Allows you to the teleport to a location on your server!")
     public void onTeleportCommand(BukkitCommandIssuer issuer,
 

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
@@ -11,7 +11,6 @@ import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.destination.ParsedDestination;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
 
 @CommandAlias("mv")
 public class TeleportCommand extends MultiverseCommand {
@@ -23,7 +22,7 @@ public class TeleportCommand extends MultiverseCommand {
     @Syntax("[player] <destination>")
     @CommandCompletion("@players|@mvworlds:playeronly|@destinations:playeronly @mvworlds|@destinations")
     @Description("Allows you to the teleport to a location on your server!")
-    public void onTeleportCommand(@NotNull CommandIssuer issuer,
+    public void onTeleportCommand(BukkitCommandIssuer issuer,
 
                                   @Flags("resolve=issueraware")
                                   @Syntax("[player]")
@@ -35,9 +34,9 @@ public class TeleportCommand extends MultiverseCommand {
                                   ParsedDestination<?> destination
     ) {
         issuer.sendMessage("Teleporting "
-                + (((BukkitCommandIssuer) issuer).getPlayer() == player ? "you" : player.getName())
+                + (issuer.getPlayer() == player ? "you" : player.getName())
                 + " to " + destination + "...");
-        this.plugin.getDestinationsProvider().playerTeleport((BukkitCommandIssuer) issuer, player, destination);
+        this.plugin.getDestinationsProvider().playerTeleport(issuer, player, destination);
     }
 
     @Override

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
@@ -20,11 +20,11 @@ public class TeleportCommand extends MultiverseCommand {
 
     @Subcommand("teleport|tp")
     @Syntax("[player] <destination>")
-    @CommandCompletion("@players|@mvworlds:playeronly|@destinations:playeronly @mvworlds|@destinations")
+    @CommandCompletion("@players|@mvworlds:playerOnly|@destinations:playerOnly @mvworlds|@destinations")
     @Description("Allows you to the teleport to a location on your server!")
     public void onTeleportCommand(BukkitCommandIssuer issuer,
 
-                                  @Flags("resolve=issueraware")
+                                  @Flags("resolve=issuerAware")
                                   @Syntax("[player]")
                                   @Description("Target player to teleport.")
                                   Player player,

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/UnloadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/UnloadCommand.java
@@ -25,7 +25,7 @@ public class UnloadCommand extends MultiverseCommand {
     public void onUnloadCommand(BukkitCommandIssuer issuer,
 
                                 @Syntax("<world>")
-                                @Description("Name of world you want to unload.")
+                                @Description("Name of the world you want to unload.")
                                 MVWorld world
     ) {
         issuer.sendMessage(String.format("Unloading world '%s'...", world.getColoredWorldString()));

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/UnloadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/UnloadCommand.java
@@ -1,0 +1,40 @@
+package com.onarandombox.MultiverseCore.commands;
+
+import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Subcommand;
+import co.aikar.commands.annotation.Syntax;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MVWorld;
+import org.jetbrains.annotations.NotNull;
+
+@CommandAlias("mv")
+public class UnloadCommand extends MultiverseCommand {
+    public UnloadCommand(@NotNull MultiverseCore plugin) {
+        super(plugin);
+    }
+
+    @Subcommand("unload")
+    @CommandPermission("multiverse.core.unload")
+    @CommandCompletion("@mvworlds")
+    @Syntax("<world>")
+    @Description("Unloads a world from Multiverse. This does NOT remove the world folder. This does NOT remove it from the config file.")
+    public void onUnloadCommand(BukkitCommandIssuer issuer,
+
+                                @Syntax("<world>")
+                                @Description("Name of world you want to unload.")
+                                MVWorld world
+    ) {
+        issuer.sendMessage(String.format("Unloading world '%s'...", world.getColoredWorldString()));
+
+        //TODO API: Should be able to use MVWorld object directly
+        if (!this.plugin.getMVWorldManager().unloadWorld(world.getName())) {
+            issuer.sendMessage(String.format("Error unloading world '%s'! See console for more details.", world.getColoredWorldString()));
+            return;
+        }
+        issuer.sendMessage(String.format("Unloaded world '%s'!", world.getColoredWorldString()));
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandCompletions.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandCompletions.java
@@ -1,24 +1,28 @@
 package com.onarandombox.MultiverseCore.commandtools;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.stream.Collectors;
+import java.util.List;
 
 import co.aikar.commands.BukkitCommandCompletionContext;
 import co.aikar.commands.BukkitCommandIssuer;
 import co.aikar.commands.PaperCommandCompletions;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MVWorld;
+import com.onarandombox.MultiverseCore.api.WorldManager;
 import org.jetbrains.annotations.NotNull;
 
 public class MVCommandCompletions extends PaperCommandCompletions {
     protected final MVCommandManager commandManager;
     private final MultiverseCore plugin;
+    private final WorldManager worldManager;
 
     public MVCommandCompletions(MVCommandManager mvCommandManager, MultiverseCore plugin) {
         super(mvCommandManager);
         this.commandManager = mvCommandManager;
         this.plugin = plugin;
+        this.worldManager = plugin.getMVWorldManager();
 
         registerAsyncCompletion("destinations", this::suggestDestinations);
         registerAsyncCompletion("flags", this::suggestFlags);
@@ -44,9 +48,24 @@ public class MVCommandCompletions extends PaperCommandCompletions {
             return Collections.emptyList();
         }
 
-        return this.plugin.getMVWorldManager().getMVWorlds()
-                .stream()
-                .map(MVWorld::getName)
-                .collect(Collectors.toList());
+        String type = context.getConfig("type", "loaded");
+
+        List<String> worlds = new ArrayList<>();
+
+        switch (type) {
+            case "includeunloaded":
+                worlds.addAll(worldManager.getUnloadedWorlds());
+            case "loaded":
+                worldManager.getMVWorlds()
+                        .stream()
+                        .map(MVWorld::getName)
+                        .forEach(worlds::add);
+                break;
+            case "unloaded":
+                worlds.addAll(worldManager.getUnloadedWorlds());
+                break;
+        }
+
+        return worlds;
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandCompletions.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandCompletions.java
@@ -30,7 +30,7 @@ public class MVCommandCompletions extends PaperCommandCompletions {
     }
 
     private Collection<String> suggestDestinations(BukkitCommandCompletionContext context) {
-        if (context.hasConfig("playeronly") && !context.getIssuer().isPlayer()) {
+        if (context.hasConfig("playerOnly") && !context.getIssuer().isPlayer()) {
             return Collections.emptyList();
         }
 
@@ -44,16 +44,14 @@ public class MVCommandCompletions extends PaperCommandCompletions {
     }
 
     private Collection<String> suggestMVWorlds(BukkitCommandCompletionContext context) {
-        if (context.hasConfig("playeronly") && !context.getIssuer().isPlayer()) {
+        if (context.hasConfig("playerOnly") && !context.getIssuer().isPlayer()) {
             return Collections.emptyList();
         }
 
-        String type = context.getConfig("type", "loaded");
-
+        String scope = context.getConfig("scope", "loaded");
         List<String> worlds = new ArrayList<>();
-
-        switch (type) {
-            case "includeunloaded":
+        switch (scope) {
+            case "both":
                 worlds.addAll(worldManager.getUnloadedWorlds());
             case "loaded":
                 worldManager.getMVWorlds()

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandConditions.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandConditions.java
@@ -7,6 +7,7 @@ import co.aikar.commands.CommandConditions;
 import co.aikar.commands.ConditionContext;
 import co.aikar.commands.ConditionFailedException;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.world.WorldNameChecker;
 
 public class MVCommandConditions {
     static void load(MVCommandManager commandManager, MultiverseCore plugin) {
@@ -58,6 +59,12 @@ public class MVCommandConditions {
             case "new":
                 if (this.plugin.getMVWorldManager().isMVWorld(worldName)) {
                     throw new ConditionFailedException("World with name '" + worldName + "' already exists!");
+                }
+                switch (WorldNameChecker.checkName(worldName)) {
+                    case INVALID_CHARS:
+                        throw new ConditionFailedException("World name '" + worldName + "' contains invalid characters!");
+                    case BLACKLISTED:
+                        throw new ConditionFailedException("World name '" + worldName + "' is used for critical server operations and is blacklisted!");
                 }
                 break;
             // Probably a typo happened here

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandConditions.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandConditions.java
@@ -30,19 +30,13 @@ public class MVCommandConditions {
                                 BukkitCommandExecutionContext executionContext,
                                 String worldName
     ) {
-        String type = context.getConfigValue("type", "loaded");
+        String scope = context.getConfigValue("scope", "loaded");
 
-        switch (type) {
+        switch (scope) {
             // Worlds that are loaded
             case "loaded":
                 if (!this.plugin.getMVWorldManager().isMVWorld(worldName)) {
                     throw new ConditionFailedException("World with name '" + worldName + "' does not exist or is not loaded!");
-                }
-                break;
-            // World that are loaded or unloaded
-            case "includeunloaded":
-                if (!this.plugin.getMVWorldManager().hasUnloadedWorld(worldName, true)) {
-                    throw new ConditionFailedException("World with name '" + worldName + "' does not exist!");
                 }
                 break;
             // Worlds that are unloaded
@@ -54,6 +48,12 @@ public class MVCommandConditions {
                     throw new ConditionFailedException("World with name '" + worldName + "' does not exist!");
                 }
                 break;
+            // World that are loaded or unloaded
+            case "both":
+                if (!this.plugin.getMVWorldManager().hasUnloadedWorld(worldName, true)) {
+                    throw new ConditionFailedException("World with name '" + worldName + "' does not exist!");
+                }
+                break;
             // World that are does not exist
             case "new":
                 if (this.plugin.getMVWorldManager().isMVWorld(worldName)) {
@@ -62,7 +62,7 @@ public class MVCommandConditions {
                 break;
             // Probably a typo happened here
             default:
-                throw new ConditionFailedException("Unknown type '" + type + "'!");
+                throw new ConditionFailedException("Unknown scope '" + scope + "'!");
         }
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandConditions.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandConditions.java
@@ -1,0 +1,68 @@
+package com.onarandombox.MultiverseCore.commandtools;
+
+import co.aikar.commands.BukkitCommandExecutionContext;
+import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.BukkitConditionContext;
+import co.aikar.commands.CommandConditions;
+import co.aikar.commands.ConditionContext;
+import co.aikar.commands.ConditionFailedException;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+
+public class MVCommandConditions {
+    static void load(MVCommandManager commandManager, MultiverseCore plugin) {
+        new MVCommandConditions(commandManager, plugin);
+    }
+
+    private final MVCommandManager commandManager;
+    private final MultiverseCore plugin;
+
+    public MVCommandConditions(MVCommandManager commandManager, MultiverseCore plugin) {
+        this.commandManager = commandManager;
+        this.plugin = plugin;
+
+        CommandConditions<BukkitCommandIssuer, BukkitCommandExecutionContext, BukkitConditionContext> conditions
+                = commandManager.getCommandConditions();
+
+        conditions.addCondition(String.class, "worldname", this::checkWorldName);
+    }
+
+    private void checkWorldName(ConditionContext<BukkitCommandIssuer> context,
+                                BukkitCommandExecutionContext executionContext,
+                                String worldName
+    ) {
+        String type = context.getConfigValue("type", "loaded");
+
+        switch (type) {
+            // Worlds that are loaded
+            case "loaded":
+                if (!this.plugin.getMVWorldManager().isMVWorld(worldName)) {
+                    throw new ConditionFailedException("World with name '" + worldName + "' does not exist or is not loaded!");
+                }
+                break;
+            // World that are loaded or unloaded
+            case "includeunloaded":
+                if (!this.plugin.getMVWorldManager().hasUnloadedWorld(worldName, true)) {
+                    throw new ConditionFailedException("World with name '" + worldName + "' does not exist!");
+                }
+                break;
+            // Worlds that are unloaded
+            case "unloaded":
+                if (!this.plugin.getMVWorldManager().hasUnloadedWorld(worldName, false)) {
+                    if (this.plugin.getMVWorldManager().isMVWorld(worldName)) {
+                        throw new ConditionFailedException("World with name '" + worldName + "' is loaded already!");
+                    }
+                    throw new ConditionFailedException("World with name '" + worldName + "' does not exist!");
+                }
+                break;
+            // World that are does not exist
+            case "new":
+                if (this.plugin.getMVWorldManager().isMVWorld(worldName)) {
+                    throw new ConditionFailedException("World with name '" + worldName + "' already exists!");
+                }
+                break;
+            // Probably a typo happened here
+            default:
+                throw new ConditionFailedException("Unknown type '" + type + "'!");
+        }
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandConditions.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandConditions.java
@@ -57,7 +57,7 @@ public class MVCommandConditions {
                 break;
             // World that are does not exist
             case "new":
-                if (this.plugin.getMVWorldManager().isMVWorld(worldName)) {
+                if (this.plugin.getMVWorldManager().hasUnloadedWorld(worldName, true)) {
                     throw new ConditionFailedException("World with name '" + worldName + "' already exists!");
                 }
                 switch (WorldNameChecker.checkName(worldName)) {

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandContexts.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandContexts.java
@@ -51,7 +51,7 @@ public class MVCommandContexts extends PaperCommandContexts {
         String resolve = context.getFlagValue("resolve", "");
 
         // Get player based on sender only
-        if (resolve.equals("issueronly")) {
+        if (resolve.equals("issuerOnly")) {
             if (context.getIssuer().isPlayer()) {
                 return context.getIssuer().getPlayer();
             }
@@ -65,7 +65,7 @@ public class MVCommandContexts extends PaperCommandContexts {
         Player player = PlayerFinder.get(playerIdentifier, context.getSender());
 
         // Get player based on input, fallback to sender if input is not a player
-        if (resolve.equals("issueraware")) {
+        if (resolve.equals("issuerAware")) {
             if (player != null) {
                 context.popFirstArg();
                 return player;

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandContexts.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandContexts.java
@@ -1,10 +1,12 @@
 package com.onarandombox.MultiverseCore.commandtools;
 
 import co.aikar.commands.BukkitCommandExecutionContext;
+import co.aikar.commands.BukkitCommandIssuer;
 import co.aikar.commands.InvalidCommandArgument;
 import co.aikar.commands.PaperCommandContexts;
 import com.google.common.base.Strings;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MVWorld;
 import com.onarandombox.MultiverseCore.destination.ParsedDestination;
 import com.onarandombox.MultiverseCore.utils.PlayerFinder;
 import org.bukkit.entity.Player;
@@ -16,6 +18,8 @@ public class MVCommandContexts extends PaperCommandContexts {
         super(mvCommandManager);
         this.plugin = plugin;
 
+        registerIssuerOnlyContext(BukkitCommandIssuer.class, BukkitCommandExecutionContext::getIssuer);
+        registerContext(MVWorld.class, this::parseMVWorld);
         registerContext(ParsedDestination.class, this::parseDestination);
         registerIssuerAwareContext(Player.class, this::parsePlayer);
     }
@@ -32,6 +36,15 @@ public class MVCommandContexts extends PaperCommandContexts {
         }
 
         return parsedDestination;
+    }
+
+    private MVWorld parseMVWorld(BukkitCommandExecutionContext context) {
+        String worldName = context.popFirstArg();
+        MVWorld world = plugin.getMVWorldManager().getMVWorld(worldName);
+        if (world == null) {
+            throw new InvalidCommandArgument("World " + worldName + " is not a multiverse world.");
+        }
+        return world;
     }
 
     private Player parsePlayer(BukkitCommandExecutionContext context) {

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/MVCommandManager.java
@@ -25,6 +25,9 @@ public class MVCommandManager extends PaperCommandManager {
         super(plugin);
         this.plugin = plugin;
 
+        // Setup conditions
+        MVCommandConditions.load(this, plugin);
+
         // Setup locale
         this.addSupportedLanguage(Locale.ENGLISH);
         this.locales.addMessageBundles("multiverse-core");

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/flags/ParsedCommandFlags.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/flags/ParsedCommandFlags.java
@@ -39,6 +39,10 @@ public class ParsedCommandFlags
         return this.flagValues.containsKey(key);
     }
 
+    public boolean hasFlagValue(@Nullable String key) {
+        return flagValue(key, Object.class) != null;
+    }
+
     /**
      * Get the value of a flag.
      *
@@ -48,5 +52,10 @@ public class ParsedCommandFlags
     public @Nullable <T> T flagValue(@Nullable String key, @NotNull Class<T> type) {
         Object value = this.flagValues.get(key);
         return (T) value;
+    }
+
+    public @NotNull <T> T flagValue(@Nullable String key, @NotNull T defaultValue, @NotNull Class<T> type) {
+        T value = flagValue(key, type);
+        return value != null ? value : defaultValue;
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/CommandQueueManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commandtools/queue/CommandQueueManager.java
@@ -7,6 +7,9 @@
 
 package com.onarandombox.MultiverseCore.commandtools.queue;
 
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import com.dumptruckman.minecraft.util.Logging;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import org.bukkit.Bukkit;
@@ -16,9 +19,6 @@ import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Map;
-import java.util.WeakHashMap;
 
 /**
  * <p>Manages the queuing of dangerous commands that require {@code /mv confirm} before executing.</p>
@@ -50,7 +50,7 @@ public class CommandQueueManager {
         // Since only one command is stored in queue per sender, we remove the old one.
         this.removeFromQueue(targetSender);
 
-        Logging.finer("Add new command to queue for sender %s.", targetSender);
+        Logging.finer("Add new command to queue for sender %s.", targetSender.getName());
         this.queuedCommandMap.put(targetSender, queuedCommand);
         queuedCommand.setExpireTask(runExpireLater(queuedCommand));
 
@@ -140,7 +140,7 @@ public class CommandQueueManager {
      */
     @NotNull
     private CommandSender parseSender(@NotNull CommandSender sender) {
-        Logging.fine(sender.getClass().getName());
+        Logging.finer("Sender is of class %s.", sender.getClass().getName());
         if (isCommandBlock(sender)) {
             Logging.finer("Is command block.");
             return COMMAND_BLOCK;

--- a/src/main/java/com/onarandombox/MultiverseCore/locale/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/locale/MVCorei18n.java
@@ -4,15 +4,26 @@ import co.aikar.locales.MessageKey;
 import co.aikar.locales.MessageKeyProvider;
 
 public enum MVCorei18n implements MessageKeyProvider {
+    CONFIG_SAVE_FAILED,
 
-        CONFIG_SAVE_FAILED,
-        DEBUG_INFO_OFF,
-        DEBUG_INFO_ON;
+    CREATE_PROPERTIES,
+    CREATE_PROPERTIES_ENVIRONMENT,
+    CREATE_PROPERTIES_SEED,
+    CREATE_PROPERTIES_WORLDTYPE,
+    CREATE_PROPERTIES_ADJUSTSPAWN,
+    CREATE_PROPERTIES_GENERATOR,
+    CREATE_PROPERTIES_STRUCTURES,
+    CREATE_LOADING,
+    CREATE_FAILED,
+    CREATE_SUCCESS,
 
-        private final MessageKey key = MessageKey.of("mv-core." + this.name().toLowerCase());
+    DEBUG_INFO_OFF,
+    DEBUG_INFO_ON;
 
-        @Override
-        public MessageKey getMessageKey() {
-            return this.key;
-        }
+    private final MessageKey key = MessageKey.of("mv-core." + this.name().toLowerCase());
+
+    @Override
+    public MessageKey getMessageKey() {
+        return this.key;
     }
+}

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -1,4 +1,20 @@
 mv-core.config_save_failed=§cUnable to save Multiverse-Core config.yml. Your changes will be temporary!
+
+mv-core.create_description=Creates a new world and loads it.
+mv-core.create_name_description=New world name.
+mv-core.create_environment_description=The world's environment. See: /mv environments
+mv-core.create_flags_description=Additional world settings. See http://gg.gg/nn8bl for all possible flags.
+mv-core.create_properties=Creating world {worldName} with the following properties:
+mv-core.create_properties_environment=- Environment: {environment}
+mv-core.create_properties_seed=- Seed: {seed}
+mv-core.create_properties_worldtype=- World Type: {worldType}
+mv-core.create_properties_adjustspawn=- Adjust Spawn: {adjustSpawn}
+mv-core.create_properties_generator=- Generator: {generator}
+mv-core.create_properties_structures=- Structures: {structures}
+mv-core.create_loading=Creating world...
+mv-core.create_failed=§cFailed to create world '{worldName}'! See console for details.
+mv-core.create_success=§aWorld '{worldName}' created successfully!
+
 mv-core.debug_info_description=Show the current debug level.
 mv-core.debug_info_off=§fMultiverse Debug mode is §cOFF§f.
 mv-core.debug_info_on=§fMultiverse Debug mode is at §alevel {level}§f.


### PR DESCRIPTION
Implemented the basic world generation commands.

- `/mv clone <world> <new-world-name>`
- `/mv confirm`
- `/mv create <name> <env> --seed [seed] --generator [generator[:id]] --world-type [worldtype] --adjust-spawn --no-structures`
- `/mv delete <world>`
- `/mv load <world>`
- `/mv unload <world>`
- `/mv regen <world> --seed [seed] --keep-gamerules`

Test Build:
[Multiverse-Core-5.0.0-SNAPSHOT.zip](https://github.com/Multiverse/Multiverse-Core/files/10687166/Multiverse-Core-5.0.0-SNAPSHOT.zip)
