### PR TITLE
Add maven central to repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ java.sourceCompatibility = JavaVersion.VERSION_11
 
 repositories {
     mavenLocal()
+    mavenCentral()
+
     maven {
         url = uri('https://hub.spigotmc.org/nexus/content/repositories/snapshots/')
     }


### PR DESCRIPTION
Some dependencies can be directly obtained from maven central, so good to add it as a repo.