### PR TITLE
Drop "Release" prefix on release names.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           bump_version_scheme: norelease
           tag_prefix: ''
-          release_name: "Release <RELEASE_VERSION>"
+          release_name: "<RELEASE_VERSION>"
           use_github_release_notes: true
 
       - name: Modify version scheme


### PR DESCRIPTION
We should probably change the `no release` label to `no version bump` or something.