### PR TITLE
i18n for strings directly in commands

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -202,7 +202,6 @@ public class MultiverseCore extends JavaPlugin implements MVCore {
      */
     private void registerCommands() {
         this.commandManager = new MVCommandManager(this);
-        this.commandManager.registerCommand(new RootCommand(this));
         this.commandManager.registerCommand(new CheckCommand(this));
         this.commandManager.registerCommand(new CloneCommand(this));
         this.commandManager.registerCommand(new ConfirmCommand(this));
@@ -215,6 +214,7 @@ public class MultiverseCore extends JavaPlugin implements MVCore {
         this.commandManager.registerCommand(new RegenCommand(this));
         this.commandManager.registerCommand(new ReloadCommand(this));
         this.commandManager.registerCommand(new RemoveCommand(this));
+        this.commandManager.registerCommand(new RootCommand(this));
         this.commandManager.registerCommand(new TeleportCommand(this));
         this.commandManager.registerCommand(new UnloadCommand(this));
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -202,6 +202,7 @@ public class MultiverseCore extends JavaPlugin implements MVCore {
      */
     private void registerCommands() {
         this.commandManager = new MVCommandManager(this);
+        this.commandManager.registerCommand(new RootCommand(this));
         this.commandManager.registerCommand(new CheckCommand(this));
         this.commandManager.registerCommand(new CloneCommand(this));
         this.commandManager.registerCommand(new ConfirmCommand(this));

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CheckCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CheckCommand.java
@@ -9,6 +9,7 @@ import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.destination.ParsedDestination;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,18 +23,20 @@ public class CheckCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.check")
     @CommandCompletion("@players @destinations|@mvworlds")
     @Syntax("<player> <destination>")
-    @Description("Checks if a player can teleport to a destination.")
+    @Description("{@@mv-core.check.description}")
     public void onCheckCommand(BukkitCommandIssuer issuer,
 
                                @Syntax("<player>")
-                               @Description("Player to check destination on.")
+                               @Description("{@@mv-core.check.player.description}")
                                Player player,
 
                                @Syntax("<destination>")
-                               @Description("A destination location, e.g. a world name.")
+                               @Description("{@@mv-core.check.destination.description}")
                                ParsedDestination<?> destination
     ) {
-        issuer.sendMessage("Checking " + player + " to " + destination + "...");
+        issuer.sendInfo(MVCorei18n.CHECK_CHECKING,
+                "{player}", player.getName(),
+                "{destination}", destination.toString());
         //TODO More detailed output on permissions required.
         this.plugin.getDestinationsProvider().checkTeleportPermissions(issuer, player, destination);
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
@@ -10,6 +10,7 @@ import co.aikar.commands.annotation.Single;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,26 +24,29 @@ public class CloneCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.clone")
     @CommandCompletion("@mvworlds:scope=both @empty")
     @Syntax("<world> <new world name>")
-    @Description("Clones a world.")
+    @Description("{@@mv-core.clone.description}")
     public void onCloneCommand(CommandIssuer issuer,
 
                                @Conditions("validWorldName:scope=both")
                                @Syntax("<world>")
-                               @Description("The target world to clone.")
+                               @Description("{@@mv-core.clone.world.description}")
                                String worldName,
 
                                @Single
                                @Conditions("validWorldName:scope=new")
                                @Syntax("<new world name>")
-                               @Description("The new cloned world name.")
+                               @Description("{@@mv-core.clone.newWorld.description}")
                                String newWorldName
     ) {
-        issuer.sendMessage(String.format("Cloning world '%s' to '%s'...", worldName, newWorldName));
+        issuer.sendInfo(MVCorei18n.CLONE_CLONING,
+                "{world}", worldName,
+                "{newWorld}", newWorldName);
 
         if (!this.plugin.getMVWorldManager().cloneWorld(worldName, newWorldName)) {
-            issuer.sendMessage(String.format("%sWorld could not be cloned! See console for more details.", ChatColor.RED));
+            issuer.sendInfo(MVCorei18n.CLONE_FAILED);
             return;
         }
-        issuer.sendMessage(String.format("%sCloned world '%s'!", ChatColor.GREEN, newWorldName));
+        issuer.sendInfo(MVCorei18n.CLONE_SUCCESS,
+                "{world}", newWorldName);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CloneCommand.java
@@ -43,7 +43,7 @@ public class CloneCommand extends MultiverseCoreCommand {
                 "{newWorld}", newWorldName);
 
         if (!this.plugin.getMVWorldManager().cloneWorld(worldName, newWorldName)) {
-            issuer.sendInfo(MVCorei18n.CLONE_FAILED);
+            issuer.sendError(MVCorei18n.CLONE_FAILED);
             return;
         }
         issuer.sendInfo(MVCorei18n.CLONE_SUCCESS,

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ConfirmCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ConfirmCommand.java
@@ -16,7 +16,7 @@ public class ConfirmCommand extends MultiverseCoreCommand {
 
     @Subcommand("confirm")
     @CommandPermission("multiverse.core.confirm")
-    @Description("Confirms dangerous commands before executing them.")
+    @Description("{@@mv-core.confirm.description}")
     public void onConfirmCommand(@NotNull BukkitCommandIssuer issuer) {
         this.plugin.getMVCommandManager().getCommandQueueManager().runQueuedCommand(issuer.getIssuer());
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package com.onarandombox.MultiverseCore.commands;
 
 import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.MessageType;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
@@ -48,7 +49,11 @@ public class DeleteCommand extends MultiverseCoreCommand {
                     issuer.sendInfo(MVCorei18n.DELETE_SUCCESS,
                             "{world}", worldName);
                 },
-                "{@@mv-core.delete.prompt}".replace("{world}", worldName)
+                this.plugin.getMVCommandManager().formatMessage(
+                        issuer,
+                        MessageType.INFO,
+                        MVCorei18n.DELETE_PROMPT,
+                        "{world}", worldName)
         ));
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
@@ -41,7 +41,7 @@ public class DeleteCommand extends MultiverseCoreCommand {
                     issuer.sendInfo(MVCorei18n.DELETE_DELETING,
                             "{world}", worldName);
                     if (!this.plugin.getMVWorldManager().deleteWorld(worldName)) {
-                        issuer.sendInfo(MVCorei18n.DELETE_FAILED,
+                        issuer.sendError(MVCorei18n.DELETE_FAILED,
                                 "{world}", worldName);
                         return;
                     }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/DeleteCommand.java
@@ -10,7 +10,9 @@ import co.aikar.commands.annotation.Single;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MVCore;
 import com.onarandombox.MultiverseCore.commandtools.queue.QueuedCommand;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,7 +26,7 @@ public class DeleteCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.delete")
     @CommandCompletion("@mvworlds:scope=both")
     @Syntax("<world>")
-    @Description("Deletes a world on your server PERMANENTLY.")
+    @Description("{@@mv-core.delete.description}")
     public void onDeleteCommand(BukkitCommandIssuer issuer,
 
                                 @Single
@@ -36,14 +38,17 @@ public class DeleteCommand extends MultiverseCoreCommand {
         this.plugin.getMVCommandManager().getCommandQueueManager().addToQueue(new QueuedCommand(
                 issuer.getIssuer(),
                 () -> {
-                    issuer.sendMessage(String.format("Deleting world '%s'...", worldName));
+                    issuer.sendInfo(MVCorei18n.DELETE_DELETING,
+                            "{world}", worldName);
                     if (!this.plugin.getMVWorldManager().deleteWorld(worldName)) {
-                        issuer.sendMessage(String.format("%sThere was an issue deleting '%s'! Please check console for errors.", ChatColor.RED, worldName));
+                        issuer.sendInfo(MVCorei18n.DELETE_FAILED,
+                                "{world}", worldName);
                         return;
                     }
-                    issuer.sendMessage(String.format("%sWorld %s was deleted!", ChatColor.GREEN, worldName));
+                    issuer.sendInfo(MVCorei18n.DELETE_SUCCESS,
+                            "{world}", worldName);
                 },
-                "Are you sure you want to delete world '" + worldName + "'?"
+                "{@@mv-core.delete.prompt}".replace("{world}", worldName)
         ));
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/GameruleCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/GameruleCommand.java
@@ -47,7 +47,7 @@ public class GameruleCommand extends MultiverseCoreCommand {
         for(MVWorld world : worlds) {
             // Set gamerules and add false to list if it fails
             if (!world.getCBWorld().setGameRule(gamerule, value)) {
-                issuer.sendInfo(MVCorei18n.GAMERULE_FAILED,
+                issuer.sendError(MVCorei18n.GAMERULE_FAILED,
                         "{gamerule}", gamerule.getName(),
                         "{value}", value.toString(),
                         "{world}", world.getName(),

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/GameruleCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/GameruleCommand.java
@@ -11,6 +11,7 @@ import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MVWorld;
 import com.onarandombox.MultiverseCore.commandtools.context.GameRuleValue;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.ChatColor;
 import org.bukkit.GameRule;
 import org.jetbrains.annotations.NotNull;
@@ -25,20 +26,20 @@ public class GameruleCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.gamerule")
     @CommandCompletion("@gamerules true|false|@range:1-10 @mvworlds:multiple|*")
     @Syntax("<Gamerule> <Gamerule value> [World or *]")
-    @Description("Changes a gamerule in one or more worlds")
+    @Description("{@@mv-core.gamerule.description}")
     public void onGameruleCommand(BukkitCommandIssuer issuer,
 
                                   @Syntax("<Gamerule>")
-                                  @Description("Gamerule to set")
+                                  @Description("{@@mv-core.gamerule.gamerule.description}")
                                   GameRule gamerule,
 
                                   @Syntax("<Value>")
-                                  @Description("Value of gamerule")
+                                  @Description("{@@mv-core.gamerule.value.description}")
                                   GameRuleValue gameRuleValue,
 
                                   @Flags("resolve=issuerAware")
                                   @Syntax("[World or *]")
-                                  @Description("World to apply gamerule to, current world by default")
+                                  @Description("{@@mv-core.gamerule.world.description}")
                                   MVWorld[] worlds
     ) {
         Object value = gameRuleValue.getValue();
@@ -46,17 +47,27 @@ public class GameruleCommand extends MultiverseCoreCommand {
         for(MVWorld world : worlds) {
             // Set gamerules and add false to list if it fails
             if (!world.getCBWorld().setGameRule(gamerule, value)) {
-                issuer.sendMessage(ChatColor.RED + "Failed to set gamerule " + gamerule.getName() + " to " + value + " in " + world.getName() + ". It should be a " + gamerule.getType());
+                issuer.sendInfo(MVCorei18n.GAMERULE_FAILED,
+                        "{gamerule}", gamerule.getName(),
+                        "{value}", value.toString(),
+                        "{world}", world.getName(),
+                        "{type}", gamerule.getType().getName());
                 success = false;
             }
         }
         // Tell user if it was successful
         if (success) {
             if (worlds.length == 1) {
-                issuer.sendMessage(ChatColor.GREEN + "Successfully set " + gamerule.getName() + " to " + value + " in " + worlds[0].getName());
+                issuer.sendInfo(MVCorei18n.GAMERULE_SUCCESS_SINGLE,
+                        "{gamerule}", gamerule.getName(),
+                        "{value}", value.toString(),
+                        "{world}", worlds[0].getName());
             }
             else if (worlds.length > 1) {
-                issuer.sendMessage(ChatColor.GREEN + "Successfully set " + gamerule.getName() + " to " + value + " in " + worlds.length + " worlds.");
+                issuer.sendInfo(MVCorei18n.GAMERULE_SUCCESS_MULTIPLE,
+                        "{gamerule}", gamerule.getName(),
+                        "{value}", value.toString(),
+                        "{count}", String.valueOf(worlds.length));
             }
         }
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
@@ -13,10 +13,12 @@ import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.api.MVCore;
 import com.onarandombox.MultiverseCore.commandtools.flags.CommandFlag;
 import com.onarandombox.MultiverseCore.commandtools.flags.CommandFlagGroup;
 import com.onarandombox.MultiverseCore.commandtools.flags.CommandValueFlag;
 import com.onarandombox.MultiverseCore.commandtools.flags.ParsedCommandFlags;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.World;
@@ -51,26 +53,27 @@ public class ImportCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.import")
     @CommandCompletion("@mvworlds:scope=potential  @flags:groupName=mvimport")
     @Syntax("<name> <env> --generator [generator[:id]] --adjust-spawn")
-    @Description("Imports a existing world folder.")
+    @Description("{@@mv-core.import.description")
     public void onImportCommand(BukkitCommandIssuer issuer,
 
                                 @Conditions("validWorldName:scope=new")
                                 @Syntax("<name>")
-                                @Description("Name of the world folder.")
+                                @Description("{@@mv-core.import.name.description}")
                                 String worldName,
 
                                 @Syntax("<env>")
-                                @Description("The world's environment. See: /mv env")
+                                @Description("{@@mv-core.import.env.description}")
                                 World.Environment environment,
 
                                 @Optional
                                 @Syntax("--generator [generator[:id]] --adjust-spawn")
-                                @Description("Other world settings. See: https://gg.gg/nn8c2")
+                                @Description("{@@mv-core.import.other.description}")
                                 String[] flags) {
 
         ParsedCommandFlags parsedFlags = parseFlags(flags);
 
-        issuer.sendMessage(String.format("Starting import of world '%s'...", worldName));
+        issuer.sendInfo(MVCorei18n.IMPORT_IMPORTING,
+                "{world}", worldName);
 
         if (!this.worldManager.addWorld(
                 worldName, environment,
@@ -80,9 +83,9 @@ public class ImportCommand extends MultiverseCoreCommand {
                 parsedFlags.flagValue("--generator", String.class),
                 parsedFlags.hasFlag("--adjust-spawn"))
         ) {
-            issuer.sendMessage(String.format("%sFailed! See console for more details.", ChatColor.RED));
+            issuer.sendInfo(MVCorei18n.IMPORT_FAILED);
             return;
         }
-        issuer.sendMessage(String.format("%sComplete!", ChatColor.GREEN));
+        issuer.sendInfo(MVCorei18n.IMPORT_SUCCESS);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
@@ -83,7 +83,7 @@ public class ImportCommand extends MultiverseCoreCommand {
                 parsedFlags.flagValue("--generator", String.class),
                 parsedFlags.hasFlag("--adjust-spawn"))
         ) {
-            issuer.sendInfo(MVCorei18n.IMPORT_FAILED);
+            issuer.sendError(MVCorei18n.IMPORT_FAILED);
             return;
         }
         issuer.sendInfo(MVCorei18n.IMPORT_SUCCESS);

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/LoadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/LoadCommand.java
@@ -10,6 +10,7 @@ import co.aikar.commands.annotation.Single;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.jetbrains.annotations.NotNull;
 
 @CommandAlias("mv")
@@ -22,21 +23,24 @@ public class LoadCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.load")
     @CommandCompletion("@mvworlds:scope=unloaded")
     @Syntax("<world>")
-    @Description("Loads a world. World must be already in worlds.yml, else please use /mv import.")
+    @Description("{@@mv-core.load.description}")
     public void onLoadCommand(BukkitCommandIssuer issuer,
 
                               @Single
                               @Conditions("validWorldName:scope=unloaded")
                               @Syntax("<world>")
-                              @Description("Name of world you want to load.")
+                              @Description("{@@mv-core.load.world.description}")
                               String worldName
     ) {
-        issuer.sendMessage(String.format("Loading world '%s'...", worldName));
+        issuer.sendInfo(MVCorei18n.LOAD_LOADING,
+            "{world}", worldName);
 
         if (!this.plugin.getMVWorldManager().loadWorld(worldName)) {
-            issuer.sendMessage(String.format("Error trying to load world '%s'!", worldName));
+            issuer.sendInfo(MVCorei18n.LOAD_FAILED,
+                    "{world}", worldName);
             return;
         }
-        issuer.sendMessage(String.format("Loaded world '%s'!", worldName));
+        issuer.sendInfo(MVCorei18n.LOAD_SUCCESS,
+                "{world}", worldName);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/LoadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/LoadCommand.java
@@ -36,7 +36,7 @@ public class LoadCommand extends MultiverseCoreCommand {
             "{world}", worldName);
 
         if (!this.plugin.getMVWorldManager().loadWorld(worldName)) {
-            issuer.sendInfo(MVCorei18n.LOAD_FAILED,
+            issuer.sendError(MVCorei18n.LOAD_FAILED,
                     "{world}", worldName);
             return;
         }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
@@ -18,6 +18,7 @@ import com.onarandombox.MultiverseCore.commandtools.flags.CommandFlagGroup;
 import com.onarandombox.MultiverseCore.commandtools.flags.CommandValueFlag;
 import com.onarandombox.MultiverseCore.commandtools.flags.ParsedCommandFlags;
 import com.onarandombox.MultiverseCore.commandtools.queue.QueuedCommand;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,17 +43,17 @@ public class RegenCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.regen")
     @CommandCompletion("@mvworlds:scope=both @flags:groupName=mvregen")
     @Syntax("<world> --seed [seed] --keep-gamerules")
-    @Description("Regenerates a world on your server. The previous state will be lost PERMANENTLY.")
+    @Description("{@@mv-core.regen.description}")
     public void onRegenCommand(BukkitCommandIssuer issuer,
 
                                @Conditions("validWorldName:scope=both")
                                @Syntax("<world>")
-                               @Description("World that you want to regen.")
+                               @Description("{@@mv-core.regen.world.description}")
                                String worldName,
 
                                @Optional
                                @Syntax("--seed [seed] --keep-gamerules")
-                               @Description("Other world settings. See: http://gg.gg/nn8lk")
+                               @Description("{@@mv-core.regen.other.description}")
                                String[] flags
     ) {
         ParsedCommandFlags parsedFlags = parseFlags(flags);
@@ -60,7 +61,8 @@ public class RegenCommand extends MultiverseCoreCommand {
         this.plugin.getMVCommandManager().getCommandQueueManager().addToQueue(new QueuedCommand(
                 issuer.getIssuer(),
                 () -> {
-                    issuer.sendMessage(String.format("Regenerating world '%s'...", worldName));
+                    issuer.sendInfo(MVCorei18n.REGEN_REGENERATING,
+                            "{world}", worldName);
                     if (!this.plugin.getMVWorldManager().regenWorld(
                             worldName,
                             parsedFlags.hasFlag("--seed"),
@@ -68,12 +70,14 @@ public class RegenCommand extends MultiverseCoreCommand {
                             parsedFlags.flagValue("--seed", String.class),
                             parsedFlags.hasFlag("--keep-gamerules")
                     )) {
-                        issuer.sendMessage(String.format("%sThere was an issue regenerating '%s'! Please check console for errors.", ChatColor.RED, worldName));
+                        issuer.sendInfo(MVCorei18n.REGEN_FAILED,
+                                "{world}", worldName);
                         return;
                     }
-                    issuer.sendMessage(String.format("%sWorld %s was regenerated!", ChatColor.GREEN, worldName));
+                    issuer.sendInfo(MVCorei18n.REGEN_SUCCESS,
+                            "{world}", worldName);
                 },
-                "Are you sure you want to regenerate world '" + worldName + "'?"
+                "{@@mv-core.regen.prompt}".replace("{world}", worldName)
         ));
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
@@ -70,7 +70,7 @@ public class RegenCommand extends MultiverseCoreCommand {
                             parsedFlags.flagValue("--seed", String.class),
                             parsedFlags.hasFlag("--keep-gamerules")
                     )) {
-                        issuer.sendInfo(MVCorei18n.REGEN_FAILED,
+                        issuer.sendError(MVCorei18n.REGEN_FAILED,
                                 "{world}", worldName);
                         return;
                     }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RegenCommand.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Random;
 
 import co.aikar.commands.BukkitCommandIssuer;
+import co.aikar.commands.MessageType;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
@@ -77,7 +78,11 @@ public class RegenCommand extends MultiverseCoreCommand {
                     issuer.sendInfo(MVCorei18n.REGEN_SUCCESS,
                             "{world}", worldName);
                 },
-                "{@@mv-core.regen.prompt}".replace("{world}", worldName)
+                this.plugin.getMVCommandManager().formatMessage(
+                        issuer,
+                        MessageType.INFO,
+                        MVCorei18n.REGEN_PROMPT,
+                        "{world}", worldName)
         ));
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ReloadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ReloadCommand.java
@@ -10,6 +10,7 @@ import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Subcommand;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.event.MVConfigReloadEvent;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,9 +22,9 @@ public class ReloadCommand extends MultiverseCoreCommand {
 
     @Subcommand("reload")
     @CommandPermission("multiverse.core.reload")
-    @Description("Reloads config files for all multiverse modules.")
+    @Description("{@@mv-core.reload.description}")
     public void onReloadCommand(@NotNull BukkitCommandIssuer issuer) {
-        issuer.sendMessage(ChatColor.GOLD + "Reloading all Multiverse Plugin configs...");
+        issuer.sendInfo(MVCorei18n.RELOAD_RELOADING);
         this.plugin.loadConfigs();
         this.plugin.getAnchorManager().loadAnchors();
         this.plugin.getMVWorldManager().loadWorlds(true);
@@ -36,7 +37,8 @@ public class ReloadCommand extends MultiverseCoreCommand {
         MVConfigReloadEvent configReload = new MVConfigReloadEvent(configsLoaded);
         this.plugin.getServer().getPluginManager().callEvent(configReload);
 
+        // @TODO: replace this sendMessage and format the configsLoaded above, maybe?
         configReload.getAllConfigsLoaded().forEach(issuer::sendMessage);
-        issuer.sendMessage(String.format("%sReload Complete!", ChatColor.GREEN));
+        issuer.sendInfo(MVCorei18n.RELOAD_SUCCESS);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RemoveCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RemoveCommand.java
@@ -34,7 +34,7 @@ public class RemoveCommand extends MultiverseCoreCommand {
                                 String worldName
     ) {
         if (!this.plugin.getMVWorldManager().removeWorldFromConfig(worldName)) {
-            issuer.sendInfo(MVCorei18n.REMOVE_FAILED);
+            issuer.sendError(MVCorei18n.REMOVE_FAILED);
             return;
         }
         issuer.sendInfo(MVCorei18n.REMOVE_SUCCESS,

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RemoveCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RemoveCommand.java
@@ -10,6 +10,7 @@ import co.aikar.commands.annotation.Single;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.ChatColor;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,19 +24,20 @@ public class RemoveCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.remove")
     @CommandCompletion("@mvworlds:scope=both")
     @Syntax("<world>")
-    @Description("Unloads a world from Multiverse and removes it from worlds.yml, this does NOT DELETE the world folder.")
+    @Description("{@@mv-core.remove.description}")
     public void onRemoveCommand(BukkitCommandIssuer issuer,
 
                                 @Single
                                 @Conditions("mvworlds:scope=both")
                                 @Syntax("<world>")
-                                @Description("World you want to remove from mv's knowledge.")
+                                @Description("{@@mv-core.remove.world.description}")
                                 String worldName
     ) {
         if (!this.plugin.getMVWorldManager().removeWorldFromConfig(worldName)) {
-            issuer.sendMessage(String.format("%sError trying to remove world from config!", ChatColor.RED));
+            issuer.sendInfo(MVCorei18n.REMOVE_FAILED);
             return;
         }
-        issuer.sendMessage(String.format("World '%s' is removed from config!", worldName));
+        issuer.sendInfo(MVCorei18n.REMOVE_SUCCESS,
+                "{world}", worldName);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/RootCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/RootCommand.java
@@ -3,6 +3,7 @@ package com.onarandombox.MultiverseCore.commands;
 import co.aikar.commands.CommandIssuer;
 import co.aikar.commands.annotation.CommandAlias;
 import com.onarandombox.MultiverseCore.MultiverseCore;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.ChatColor;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.jetbrains.annotations.NotNull;
@@ -15,7 +16,9 @@ public class RootCommand extends MultiverseCoreCommand {
     @CommandAlias("mv")
     public void onRootCommand(CommandIssuer issuer) {
         PluginDescriptionFile description = this.plugin.getDescription();
-        issuer.sendMessage(ChatColor.GREEN + description.getName() + " version " + description.getVersion());
-        issuer.sendMessage(ChatColor.GREEN + "See " + ChatColor.WHITE + "/mv help" + ChatColor.GREEN + " for commands available.");
+        issuer.sendInfo(MVCorei18n.ROOT_TITLE,
+                "{name}", description.getName(),
+                "{version}", description.getVersion());
+        issuer.sendInfo(MVCorei18n.ROOT_HELP);
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/TeleportCommand.java
@@ -10,6 +10,7 @@ import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.destination.ParsedDestination;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.bukkit.entity.Player;
 
 @CommandAlias("mv")
@@ -21,23 +22,23 @@ public class TeleportCommand extends MultiverseCoreCommand {
     @Subcommand("teleport|tp")
     @CommandCompletion("@players|@mvworlds:playerOnly|@destinations:playerOnly @mvworlds|@destinations")
     @Syntax("[player] <destination>")
-    @Description("Allows you to the teleport to a location on your server!")
+    @Description("{@@mv-core.teleport.description}")
     public void onTeleportCommand(BukkitCommandIssuer issuer,
 
                                   @Flags("resolve=issuerAware")
                                   @Syntax("[player]")
-                                  @Description("Target player to teleport.")
+                                  @Description("{@@mv-core.teleport.player.description}")
                                   Player[] players,
 
                                   @Syntax("<destination>")
-                                  @Description("Location, can be a world name.")
+                                  @Description("{@@mv-core.teleport.destination.description}")
                                   ParsedDestination<?> destination
     ) {
         // TODO Add warning if teleporting too many players at once.
         for (Player player : players) {
-            issuer.sendMessage("Teleporting "
-                    + (issuer.getPlayer() == player ? "you" : player.getName())
-                    + " to " + destination + "...");
+            issuer.sendInfo(MVCorei18n.TELEPORT_SUCCESS,
+                    "{player}", issuer.getPlayer() == player ? "you" : player.getName(),
+                    "{destination}", destination.toString());
             this.plugin.getDestinationsProvider().playerTeleport(issuer, player, destination);
         }
     }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/UnloadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/UnloadCommand.java
@@ -9,6 +9,7 @@ import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import com.onarandombox.MultiverseCore.MultiverseCore;
 import com.onarandombox.MultiverseCore.api.MVWorld;
+import com.onarandombox.MultiverseCore.utils.MVCorei18n;
 import org.jetbrains.annotations.NotNull;
 
 @CommandAlias("mv")
@@ -21,20 +22,23 @@ public class UnloadCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.unload")
     @CommandCompletion("@mvworlds")
     @Syntax("<world>")
-    @Description("Unloads a world from Multiverse. This does NOT remove the world folder. This does NOT remove it from the config file.")
+    @Description("{@@mv-core.unload.description}")
     public void onUnloadCommand(BukkitCommandIssuer issuer,
 
                                 @Syntax("<world>")
-                                @Description("Name of the world you want to unload.")
+                                @Description("{@@mv-core.unload.world.description}")
                                 MVWorld world
     ) {
-        issuer.sendMessage(String.format("Unloading world '%s'...", world.getColoredWorldString()));
+        issuer.sendInfo(MVCorei18n.UNLOAD_UNLOADING,
+                "{world}", world.getColoredWorldString());
 
         //TODO API: Should be able to use MVWorld object directly
         if (!this.plugin.getMVWorldManager().unloadWorld(world.getName())) {
-            issuer.sendMessage(String.format("Error unloading world '%s'! See console for more details.", world.getColoredWorldString()));
+            issuer.sendInfo(MVCorei18n.UNLOAD_FAILURE,
+                    "{world}", world.getColoredWorldString());
             return;
         }
-        issuer.sendMessage(String.format("Unloaded world '%s'!", world.getColoredWorldString()));
+        issuer.sendInfo(MVCorei18n.UNLOAD_SUCCESS,
+                "{world}", world.getColoredWorldString());
     }
 }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/UnloadCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/UnloadCommand.java
@@ -34,7 +34,7 @@ public class UnloadCommand extends MultiverseCoreCommand {
 
         //TODO API: Should be able to use MVWorld object directly
         if (!this.plugin.getMVWorldManager().unloadWorld(world.getName())) {
-            issuer.sendInfo(MVCorei18n.UNLOAD_FAILURE,
+            issuer.sendError(MVCorei18n.UNLOAD_FAILURE,
                     "{world}", world.getColoredWorldString());
             return;
         }

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/UsageCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/UsageCommand.java
@@ -22,7 +22,7 @@ public class UsageCommand extends MultiverseCoreCommand {
     @CommandPermission("multiverse.core.help")
     @CommandCompletion("@commands:mv")
     @Syntax("[filter] [page]")
-    @Description("Show Multiverse-Core Command usage.")
+    @Description("{@@mv-core.usage.description}")
     public void onUsageCommand(CommandHelp help) {
         if (help.getIssuer().isPlayer()) {
             // Prevent flooding the chat

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -24,6 +24,11 @@ public enum MVCorei18n implements MessageKeyProvider {
     CREATE_FAILED,
     CREATE_SUCCESS,
 
+    // delete command
+    DELETE_DELETING,
+    DELETE_FAILED,
+    DELETE_SUCCESS,
+    DELETE_PROMPT,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -54,6 +54,10 @@ public enum MVCorei18n implements MessageKeyProvider {
     // reload command
     RELOAD_RELOADING,
     RELOAD_SUCCESS,
+
+    // remove command
+    REMOVE_FAILED,
+    REMOVE_SUCCESS,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -58,6 +58,10 @@ public enum MVCorei18n implements MessageKeyProvider {
     // remove command
     REMOVE_FAILED,
     REMOVE_SUCCESS,
+
+    // root MV command
+    ROOT_TITLE,
+    ROOT_HELP,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -6,6 +6,8 @@ import co.aikar.locales.MessageKeyProvider;
 public enum MVCorei18n implements MessageKeyProvider {
     CONFIG_SAVE_FAILED,
 
+    // check command
+    CHECK_CHECKING,
     CREATE_PROPERTIES,
     CREATE_PROPERTIES_ENVIRONMENT,
     CREATE_PROPERTIES_SEED,

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -44,6 +44,12 @@ public enum MVCorei18n implements MessageKeyProvider {
     LOAD_LOADING,
     LOAD_FAILED,
     LOAD_SUCCESS,
+
+    // regen command
+    REGEN_REGENERATING,
+    REGEN_FAILED,
+    REGEN_SUCCESS,
+    REGEN_PROMPT,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -34,6 +34,11 @@ public enum MVCorei18n implements MessageKeyProvider {
     GAMERULE_FAILED,
     GAMERULE_SUCCESS_SINGLE,
     GAMERULE_SUCCESS_MULTIPLE,
+
+    // import command
+    IMPORT_IMPORTING,
+    IMPORT_FAILED,
+    IMPORT_SUCCESS,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -4,6 +4,7 @@ import co.aikar.locales.MessageKey;
 import co.aikar.locales.MessageKeyProvider;
 
 public enum MVCorei18n implements MessageKeyProvider {
+    // config status
     CONFIG_SAVE_FAILED,
 
     // check command
@@ -13,6 +14,8 @@ public enum MVCorei18n implements MessageKeyProvider {
     CLONE_CLONING,
     CLONE_FAILED,
     CLONE_SUCCESS,
+
+    // create command
     CREATE_PROPERTIES,
     CREATE_PROPERTIES_ENVIRONMENT,
     CREATE_PROPERTIES_SEED,
@@ -70,6 +73,8 @@ public enum MVCorei18n implements MessageKeyProvider {
     UNLOAD_UNLOADING,
     UNLOAD_FAILURE,
     UNLOAD_SUCCESS,
+
+    // debug command
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -8,6 +8,11 @@ public enum MVCorei18n implements MessageKeyProvider {
 
     // check command
     CHECK_CHECKING,
+
+    // clone command
+    CLONE_CLONING,
+    CLONE_FAILED,
+    CLONE_SUCCESS,
     CREATE_PROPERTIES,
     CREATE_PROPERTIES_ENVIRONMENT,
     CREATE_PROPERTIES_SEED,

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -39,6 +39,11 @@ public enum MVCorei18n implements MessageKeyProvider {
     IMPORT_IMPORTING,
     IMPORT_FAILED,
     IMPORT_SUCCESS,
+
+    // load command
+    LOAD_LOADING,
+    LOAD_FAILED,
+    LOAD_SUCCESS,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -62,6 +62,9 @@ public enum MVCorei18n implements MessageKeyProvider {
     // root MV command
     ROOT_TITLE,
     ROOT_HELP,
+
+    // teleport command
+    TELEPORT_SUCCESS,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -50,6 +50,10 @@ public enum MVCorei18n implements MessageKeyProvider {
     REGEN_FAILED,
     REGEN_SUCCESS,
     REGEN_PROMPT,
+
+    // reload command
+    RELOAD_RELOADING,
+    RELOAD_SUCCESS,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -29,6 +29,11 @@ public enum MVCorei18n implements MessageKeyProvider {
     DELETE_FAILED,
     DELETE_SUCCESS,
     DELETE_PROMPT,
+
+    // gamerule command
+    GAMERULE_FAILED,
+    GAMERULE_SUCCESS_SINGLE,
+    GAMERULE_SUCCESS_MULTIPLE,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/MVCorei18n.java
@@ -65,6 +65,11 @@ public enum MVCorei18n implements MessageKeyProvider {
 
     // teleport command
     TELEPORT_SUCCESS,
+
+    // unload command
+    UNLOAD_UNLOADING,
+    UNLOAD_FAILURE,
+    UNLOAD_SUCCESS,
     DEBUG_INFO_OFF,
     DEBUG_INFO_ON;
 

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -1,5 +1,9 @@
 mv-core.config.save.failed=&cUnable to save Multiverse-Core config.yml. Your changes will be temporary!
 
+mv-core.check.description=Checks if a player can teleport to a destination.
+mv-core.check.player.description=Player to check destination on.
+mv-core.check.destination.description=A destination location, e.g. a world name.
+mv-core.check.checking=Checking {player} to {destination} ..
 mv-core.create.description=Creates a new world and loads it.
 mv-core.create.name.description=New world name.
 mv-core.create.environment.description=The world's environment. See: /mv environments

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -34,6 +34,14 @@ mv-core.create.loading=Creating world...
 mv-core.create.failed=&cFailed to create world '{worldName}'! &fSee console for details.
 mv-core.create.success=&aWorld '{worldName}' created successfully!
 
+# /mv debug
+mv-core.debug.info.description=Show the current debug level.
+mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
+mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.
+mv-core.debug.change.description=Change debug level.
+mv-core.debug.change.syntax=level
+mv-core.debug.change.level.description=Debug level to set to.
+
 # /mv delete
 mv-core.delete.description=Deletes a world on your server PERMANENTLY.
 mv-core.delete.deleting=Deleting world '{world}'...
@@ -105,11 +113,3 @@ mv-core.unload.success=&aUnloaded world '{world}'!
 
 # /mv usage
 mv-core.usage.description=Show Multiverse-Core command usage.
-
-# /mv debug
-mv-core.debug.info.description=Show the current debug level.
-mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
-mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.
-mv-core.debug.change.description=Change debug level.
-mv-core.debug.change.syntax=level
-mv-core.debug.change.level.description=Debug level to set to.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -70,6 +70,9 @@ mv-core.remove.description=Unloads a world from Multiverse and removes it from w
 mv-core.remove.world.description=World you want to remove from MV's knowledge.
 mv-core.remove.failed=Error trying to remove world from config!
 mv-core.remove.success=World '{world}' is removed from config!
+
+mv-core.root.title={name} version {version}
+mv-core.root.help=See /mv help for commands available.
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -26,6 +26,11 @@ mv-core.create.loading=Creating world...
 mv-core.create.failed=&cFailed to create world '{worldName}'! See console for details.
 mv-core.create.success=&aWorld '{worldName}' created successfully!
 
+mv-core.delete.description=Deletes a world on your server PERMANENTLY.
+mv-core.delete.deleting=Deleting world '{world}'...
+mv-core.delete.failed=There was an issue deleting '{world}'! Please check console for errors.
+mv-core.delete.success=World {world} was deleted!
+mv-core.delete.prompt=Are you sure you want to delete world '{world}'?
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -31,6 +31,14 @@ mv-core.delete.deleting=Deleting world '{world}'...
 mv-core.delete.failed=There was an issue deleting '{world}'! Please check console for errors.
 mv-core.delete.success=World {world} was deleted!
 mv-core.delete.prompt=Are you sure you want to delete world '{world}'?
+
+mv-core.gamerule.description=Changes a gamerule in one or more worlds
+mv-core.gamerule.gamerule.description=Gamerule to set
+mv-core.gamerule.value.description=Value of gamerule
+mv-core.gamerule.world.description=World to apply gamerule to, current world by default
+mv-core.gamerule.failed=Failed to set gamerule {gamerule} to {value} in {world}. It should be a {type}.
+mv-core.gamerule.success.single=Successfully set {gamerule} to {value} in {world}.
+mv-core.gamerule.success.multiple=Successfully set {gamerule} to {value} in {count} worlds.
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -53,6 +53,14 @@ mv-core.load.world.description=Name of world you want to load.
 mv-core.load.loading=Loading world '{world}'...
 mv-core.load.failed=Error trying to load world '{world}'!
 mv-core.load.success=Loaded world '{world}'!
+
+mv-core.regen.description=Regenerates a world on your server. The previous state will be lost PERMANENTLY.
+mv-core.regen.world.description=World that you want to regen.
+mv-core.regen.other.description=Other world settings. See: http://gg.gg/nn8lk
+mv-core.regen.regenerating=Regenerating world '{world}'...
+mv-core.regen.failed=There was an issue regenerating '{world}'! Please check console for errors.
+mv-core.regen.success=World {world} was regenerated!
+mv-core.regen.prompt=Are you sure you want to regenerate world '{world}'?
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -61,6 +61,10 @@ mv-core.regen.regenerating=Regenerating world '{world}'...
 mv-core.regen.failed=There was an issue regenerating '{world}'! Please check console for errors.
 mv-core.regen.success=World {world} was regenerated!
 mv-core.regen.prompt=Are you sure you want to regenerate world '{world}'?
+
+mv-core.reload.description=Reloads config files for all Multiverse modules.
+mv-core.reload.reloading=Reloading all Multiverse Plugin configs...
+mv-core.reload.success=Reload complete!
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -4,6 +4,13 @@ mv-core.check.description=Checks if a player can teleport to a destination.
 mv-core.check.player.description=Player to check destination on.
 mv-core.check.destination.description=A destination location, e.g. a world name.
 mv-core.check.checking=Checking {player} to {destination} ..
+
+mv-core.clone.description=Clones a world.
+mv-core.clone.world.description=The target world to clone.
+mv-core.clone.newWorld.description=The new cloned world name.
+mv-core.clone.cloning=Cloning world '{world}' to '{newworld}'...
+mv-core.clone.failed=World could not be cloned! See console for more details.
+mv-core.clone.success=Cloned world '{world}'!
 mv-core.create.description=Creates a new world and loads it.
 mv-core.create.name.description=New world name.
 mv-core.create.environment.description=The world's environment. See: /mv environments

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -11,6 +11,9 @@ mv-core.clone.newWorld.description=The new cloned world name.
 mv-core.clone.cloning=Cloning world '{world}' to '{newworld}'...
 mv-core.clone.failed=World could not be cloned! See console for more details.
 mv-core.clone.success=Cloned world '{world}'!
+
+mv-core.confirm.description=Confirms dangerous commands before executing them.
+
 mv-core.create.description=Creates a new world and loads it.
 mv-core.create.name.description=New world name.
 mv-core.create.environment.description=The world's environment. See: /mv environments

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -1,10 +1,13 @@
+# configuration
 mv-core.config.save.failed=&cUnable to save Multiverse-Core config.yml. Your changes will be temporary!
 
+# /mv check
 mv-core.check.description=Checks if a player can teleport to a destination.
 mv-core.check.player.description=Player to check destination on.
 mv-core.check.destination.description=A destination location, e.g. a world name.
 mv-core.check.checking=Checking {player} to {destination} ..
 
+# /mv clone
 mv-core.clone.description=Clones a world.
 mv-core.clone.world.description=The target world to clone.
 mv-core.clone.newWorld.description=The new cloned world name.
@@ -12,8 +15,10 @@ mv-core.clone.cloning=Cloning world '{world}' to '{newworld}'...
 mv-core.clone.failed=&cWorld could not be cloned! &fSee console for more details.
 mv-core.clone.success=Cloned world '{world}'!
 
+# /mv confirm
 mv-core.confirm.description=Confirms dangerous commands before executing them.
 
+# /mv create
 mv-core.create.description=Creates a new world and loads it.
 mv-core.create.name.description=New world name.
 mv-core.create.environment.description=The world's environment. See: /mv environments
@@ -29,12 +34,14 @@ mv-core.create.loading=Creating world...
 mv-core.create.failed=&cFailed to create world '{worldName}'! &fSee console for details.
 mv-core.create.success=&aWorld '{worldName}' created successfully!
 
+# /mv delete
 mv-core.delete.description=Deletes a world on your server PERMANENTLY.
 mv-core.delete.deleting=Deleting world '{world}'...
 mv-core.delete.failed=&cThere was an issue deleting '{world}'! &fPlease check console for errors.
 mv-core.delete.success=&aWorld {world} was deleted!
 mv-core.delete.prompt=Are you sure you want to delete world '{world}'?
 
+# /mv gamerule
 mv-core.gamerule.description=Changes a gamerule in one or more worlds
 mv-core.gamerule.gamerule.description=Gamerule to set
 mv-core.gamerule.value.description=Value of gamerule
@@ -43,6 +50,7 @@ mv-core.gamerule.failed=&cFailed to set gamerule {gamerule} to {value} in {world
 mv-core.gamerule.success.single=&aSuccessfully set {gamerule} to {value} in {world}.
 mv-core.gamerule.success.multiple=&aSuccessfully set {gamerule} to {value} in {count} worlds.
 
+# /mv import
 mv-core.import.description=Imports an existing world folder.
 mv-core.import.name.description=Name of the world folder.
 mv-core.import.env.description=The world's environment. See: /mv env
@@ -51,12 +59,14 @@ mv-core.import.importing=Starting import of world '{world}'...
 mv-core.import.failed=&cFailed! &fSee console for more details.
 mv-core.import.success=&aComplete!
 
+# /mv load
 mv-core.load.description=Loads a world. World must be already in worlds.yml, else please use /mv import.
 mv-core.load.world.description=Name of world you want to load.
 mv-core.load.loading=Loading world '{world}'...
 mv-core.load.failed=&cError trying to load world '{world}'!
 mv-core.load.success=&aLoaded world '{world}'!
 
+# /mv regen
 mv-core.regen.description=Regenerates a world on your server. The previous state will be lost PERMANENTLY.
 mv-core.regen.world.description=World that you want to regen.
 mv-core.regen.other.description=Other world settings. See: http://gg.gg/nn8lk
@@ -65,31 +75,38 @@ mv-core.regen.failed=&cThere was an issue regenerating '{world}'! &fPlease check
 mv-core.regen.success=&aWorld {world} was regenerated!
 mv-core.regen.prompt=Are you sure you want to regenerate world '{world}'?
 
+# /mv reload
 mv-core.reload.description=Reloads config files for all Multiverse modules.
 mv-core.reload.reloading=&6Reloading all Multiverse Plugin configs...
 mv-core.reload.success=&aReload complete!
 
+# /mv remove
 mv-core.remove.description=Unloads a world from Multiverse and removes it from worlds.yml. This does NOT delete the world folder.
 mv-core.remove.world.description=World you want to remove from MV's knowledge.
 mv-core.remove.failed=&cError trying to remove world from config!
 mv-core.remove.success=&aWorld '{world}' is removed from config!
 
+# /mv
 mv-core.root.title=&a{name} version {version}
 mv-core.root.help=&aSee &f/mv help&a for commands available.
 
+# /mv tp
 mv-core.teleport.description=Allows you to teleport to a location on your server!
 mv-core.teleport.player.description=Target player to teleport.
 mv-core.teleport.destination.description=Location, can be a world name.
 mv-core.teleport.success=Teleporting {player} to {destination}...
 
+# /mv unload
 mv-core.unload.description=Unloads a world from Multiverse. This does NOT remove the world folder. This does NOT remove it from the config file.
 mv-core.unload.world.description=Name of the world you want to unload.
 mv-core.unload.unloading=Unloading world '{world}'...
 mv-core.unload.failure=&cError unloading world '{world}'! &fSee console for more details.
 mv-core.unload.success=&aUnloaded world '{world}'!
 
+# /mv usage
 mv-core.usage.description=Show Multiverse-Core command usage.
 
+# /mv debug
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -65,6 +65,11 @@ mv-core.regen.prompt=Are you sure you want to regenerate world '{world}'?
 mv-core.reload.description=Reloads config files for all Multiverse modules.
 mv-core.reload.reloading=Reloading all Multiverse Plugin configs...
 mv-core.reload.success=Reload complete!
+
+mv-core.remove.description=Unloads a world from Multiverse and removes it from worlds.yml. This does NOT delete the world folder.
+mv-core.remove.world.description=World you want to remove from MV's knowledge.
+mv-core.remove.failed=Error trying to remove world from config!
+mv-core.remove.success=World '{world}' is removed from config!
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -47,6 +47,12 @@ mv-core.import.other.description=Other world settings. See: https://gg.gg/nn8c2
 mv-core.import.importing=Starting import of world '{world}'...
 mv-core.import.failed=Failed! See console for more details.
 mv-core.import.success=Complete!
+
+mv-core.load.description=Loads a world. World must be already in worlds.yml, else please use /mv import.
+mv-core.load.world.description=Name of world you want to load.
+mv-core.load.loading=Loading world '{world}'...
+mv-core.load.failed=Error trying to load world '{world}'!
+mv-core.load.success=Loaded world '{world}'!
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -39,6 +39,14 @@ mv-core.gamerule.world.description=World to apply gamerule to, current world by 
 mv-core.gamerule.failed=Failed to set gamerule {gamerule} to {value} in {world}. It should be a {type}.
 mv-core.gamerule.success.single=Successfully set {gamerule} to {value} in {world}.
 mv-core.gamerule.success.multiple=Successfully set {gamerule} to {value} in {count} worlds.
+
+mv-core.import.description=Imports an existing world folder.
+mv-core.import.name.description=Name of the world folder.
+mv-core.import.env.description=The world's environment. See: /mv env
+mv-core.import.other.description=Other world settings. See: https://gg.gg/nn8c2
+mv-core.import.importing=Starting import of world '{world}'...
+mv-core.import.failed=Failed! See console for more details.
+mv-core.import.success=Complete!
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -84,6 +84,9 @@ mv-core.unload.world.description=Name of the world you want to unload.
 mv-core.unload.unloading=Unloading world '{world}'...
 mv-core.unload.failure=Error unloading world '{world}'! See console for more details.
 mv-core.unload.success=Unloaded world '{world}'!
+
+mv-core.usage.description=Show Multiverse-Core command usage.
+
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -73,6 +73,11 @@ mv-core.remove.success=World '{world}' is removed from config!
 
 mv-core.root.title={name} version {version}
 mv-core.root.help=See /mv help for commands available.
+
+mv-core.teleport.description=Allows you to teleport to a location on your server!
+mv-core.teleport.player.description=Target player to teleport.
+mv-core.teleport.destination.description=Location, can be a world name.
+mv-core.teleport.success=Teleporting {player} to {destination}...
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -78,6 +78,12 @@ mv-core.teleport.description=Allows you to teleport to a location on your server
 mv-core.teleport.player.description=Target player to teleport.
 mv-core.teleport.destination.description=Location, can be a world name.
 mv-core.teleport.success=Teleporting {player} to {destination}...
+
+mv-core.unload.description=Unloads a world from Multiverse. This does NOT remove the world folder. This does NOT remove it from the config file.
+mv-core.unload.world.description=Name of the world you want to unload.
+mv-core.unload.unloading=Unloading world '{world}'...
+mv-core.unload.failure=Error unloading world '{world}'! See console for more details.
+mv-core.unload.success=Unloaded world '{world}'!
 mv-core.debug.info.description=Show the current debug level.
 mv-core.debug.info.off=&fMultiverse Debug mode is &cOFF&f.
 mv-core.debug.info.on=&fMultiverse Debug mode is at &alevel {level}&f.

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -9,7 +9,7 @@ mv-core.clone.description=Clones a world.
 mv-core.clone.world.description=The target world to clone.
 mv-core.clone.newWorld.description=The new cloned world name.
 mv-core.clone.cloning=Cloning world '{world}' to '{newworld}'...
-mv-core.clone.failed=World could not be cloned! See console for more details.
+mv-core.clone.failed=&cWorld could not be cloned! &fSee console for more details.
 mv-core.clone.success=Cloned world '{world}'!
 
 mv-core.confirm.description=Confirms dangerous commands before executing them.
@@ -26,56 +26,56 @@ mv-core.create.properties.adjustspawn=- Adjust Spawn: {adjustSpawn}
 mv-core.create.properties.generator=- Generator: {generator}
 mv-core.create.properties.structures=- Structures: {structures}
 mv-core.create.loading=Creating world...
-mv-core.create.failed=&cFailed to create world '{worldName}'! See console for details.
+mv-core.create.failed=&cFailed to create world '{worldName}'! &fSee console for details.
 mv-core.create.success=&aWorld '{worldName}' created successfully!
 
 mv-core.delete.description=Deletes a world on your server PERMANENTLY.
 mv-core.delete.deleting=Deleting world '{world}'...
-mv-core.delete.failed=There was an issue deleting '{world}'! Please check console for errors.
-mv-core.delete.success=World {world} was deleted!
+mv-core.delete.failed=&cThere was an issue deleting '{world}'! &fPlease check console for errors.
+mv-core.delete.success=&aWorld {world} was deleted!
 mv-core.delete.prompt=Are you sure you want to delete world '{world}'?
 
 mv-core.gamerule.description=Changes a gamerule in one or more worlds
 mv-core.gamerule.gamerule.description=Gamerule to set
 mv-core.gamerule.value.description=Value of gamerule
 mv-core.gamerule.world.description=World to apply gamerule to, current world by default
-mv-core.gamerule.failed=Failed to set gamerule {gamerule} to {value} in {world}. It should be a {type}.
-mv-core.gamerule.success.single=Successfully set {gamerule} to {value} in {world}.
-mv-core.gamerule.success.multiple=Successfully set {gamerule} to {value} in {count} worlds.
+mv-core.gamerule.failed=&cFailed to set gamerule {gamerule} to {value} in {world}. &fIt should be a {type}.
+mv-core.gamerule.success.single=&aSuccessfully set {gamerule} to {value} in {world}.
+mv-core.gamerule.success.multiple=&aSuccessfully set {gamerule} to {value} in {count} worlds.
 
 mv-core.import.description=Imports an existing world folder.
 mv-core.import.name.description=Name of the world folder.
 mv-core.import.env.description=The world's environment. See: /mv env
 mv-core.import.other.description=Other world settings. See: https://gg.gg/nn8c2
 mv-core.import.importing=Starting import of world '{world}'...
-mv-core.import.failed=Failed! See console for more details.
-mv-core.import.success=Complete!
+mv-core.import.failed=&cFailed! &fSee console for more details.
+mv-core.import.success=&aComplete!
 
 mv-core.load.description=Loads a world. World must be already in worlds.yml, else please use /mv import.
 mv-core.load.world.description=Name of world you want to load.
 mv-core.load.loading=Loading world '{world}'...
-mv-core.load.failed=Error trying to load world '{world}'!
-mv-core.load.success=Loaded world '{world}'!
+mv-core.load.failed=&cError trying to load world '{world}'!
+mv-core.load.success=&aLoaded world '{world}'!
 
 mv-core.regen.description=Regenerates a world on your server. The previous state will be lost PERMANENTLY.
 mv-core.regen.world.description=World that you want to regen.
 mv-core.regen.other.description=Other world settings. See: http://gg.gg/nn8lk
 mv-core.regen.regenerating=Regenerating world '{world}'...
-mv-core.regen.failed=There was an issue regenerating '{world}'! Please check console for errors.
-mv-core.regen.success=World {world} was regenerated!
+mv-core.regen.failed=&cThere was an issue regenerating '{world}'! &fPlease check console for errors.
+mv-core.regen.success=&aWorld {world} was regenerated!
 mv-core.regen.prompt=Are you sure you want to regenerate world '{world}'?
 
 mv-core.reload.description=Reloads config files for all Multiverse modules.
-mv-core.reload.reloading=Reloading all Multiverse Plugin configs...
-mv-core.reload.success=Reload complete!
+mv-core.reload.reloading=&6Reloading all Multiverse Plugin configs...
+mv-core.reload.success=&aReload complete!
 
 mv-core.remove.description=Unloads a world from Multiverse and removes it from worlds.yml. This does NOT delete the world folder.
 mv-core.remove.world.description=World you want to remove from MV's knowledge.
-mv-core.remove.failed=Error trying to remove world from config!
-mv-core.remove.success=World '{world}' is removed from config!
+mv-core.remove.failed=&cError trying to remove world from config!
+mv-core.remove.success=&aWorld '{world}' is removed from config!
 
-mv-core.root.title={name} version {version}
-mv-core.root.help=See /mv help for commands available.
+mv-core.root.title=&a{name} version {version}
+mv-core.root.help=&aSee &f/mv help&a for commands available.
 
 mv-core.teleport.description=Allows you to teleport to a location on your server!
 mv-core.teleport.player.description=Target player to teleport.
@@ -85,8 +85,8 @@ mv-core.teleport.success=Teleporting {player} to {destination}...
 mv-core.unload.description=Unloads a world from Multiverse. This does NOT remove the world folder. This does NOT remove it from the config file.
 mv-core.unload.world.description=Name of the world you want to unload.
 mv-core.unload.unloading=Unloading world '{world}'...
-mv-core.unload.failure=Error unloading world '{world}'! See console for more details.
-mv-core.unload.success=Unloaded world '{world}'!
+mv-core.unload.failure=&cError unloading world '{world}'! &fSee console for more details.
+mv-core.unload.success=&aUnloaded world '{world}'!
 
 mv-core.usage.description=Show Multiverse-Core command usage.
 

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -1,5 +1,5 @@
 # configuration
-mv-core.config.save.failed=&cUnable to save Multiverse-Core config.yml. Your changes will be temporary!
+mv-core.config.save.failed=Unable to save Multiverse-Core config.yml. Your changes will be temporary!
 
 # /mv check
 mv-core.check.description=Checks if a player can teleport to a destination.
@@ -12,7 +12,7 @@ mv-core.clone.description=Clones a world.
 mv-core.clone.world.description=The target world to clone.
 mv-core.clone.newWorld.description=The new cloned world name.
 mv-core.clone.cloning=Cloning world '{world}' to '{newworld}'...
-mv-core.clone.failed=&cWorld could not be cloned! &fSee console for more details.
+mv-core.clone.failed=World could not be cloned! &fSee console for more details.
 mv-core.clone.success=Cloned world '{world}'!
 
 # /mv confirm
@@ -24,14 +24,14 @@ mv-core.create.name.description=New world name.
 mv-core.create.environment.description=The world's environment. See: /mv environments
 mv-core.create.flags.description=Additional world settings. See https://gg.gg/nn8bl for all possible flags.
 mv-core.create.properties=Creating world {worldName} with the following properties:
-mv-core.create.properties.environment=- Environment: {environment}
-mv-core.create.properties.seed=- Seed: {seed}
-mv-core.create.properties.worldtype=- World Type: {worldType}
-mv-core.create.properties.adjustspawn=- Adjust Spawn: {adjustSpawn}
-mv-core.create.properties.generator=- Generator: {generator}
-mv-core.create.properties.structures=- Structures: {structures}
+mv-core.create.properties.environment=- Environment: &f{environment}
+mv-core.create.properties.seed=- Seed: &f{seed}
+mv-core.create.properties.worldtype=- World Type: &f{worldType}
+mv-core.create.properties.adjustspawn=- Adjust Spawn: &f{adjustSpawn}
+mv-core.create.properties.generator=- Generator: &f{generator}
+mv-core.create.properties.structures=- Structures: &f{structures}
 mv-core.create.loading=Creating world...
-mv-core.create.failed=&cFailed to create world '{worldName}'! &fSee console for details.
+mv-core.create.failed=Failed to create world '{worldName}'! &fSee console for details.
 mv-core.create.success=&aWorld '{worldName}' created successfully!
 
 # /mv debug
@@ -45,7 +45,7 @@ mv-core.debug.change.level.description=Debug level to set to.
 # /mv delete
 mv-core.delete.description=Deletes a world on your server PERMANENTLY.
 mv-core.delete.deleting=Deleting world '{world}'...
-mv-core.delete.failed=&cThere was an issue deleting '{world}'! &fPlease check console for errors.
+mv-core.delete.failed=There was an issue deleting '{world}'! &fPlease check console for errors.
 mv-core.delete.success=&aWorld {world} was deleted!
 mv-core.delete.prompt=Are you sure you want to delete world '{world}'?
 
@@ -54,7 +54,7 @@ mv-core.gamerule.description=Changes a gamerule in one or more worlds
 mv-core.gamerule.gamerule.description=Gamerule to set
 mv-core.gamerule.value.description=Value of gamerule
 mv-core.gamerule.world.description=World to apply gamerule to, current world by default
-mv-core.gamerule.failed=&cFailed to set gamerule {gamerule} to {value} in {world}. &fIt should be a {type}.
+mv-core.gamerule.failed=Failed to set gamerule {gamerule} to {value} in {world}. &fIt should be a {type}.
 mv-core.gamerule.success.single=&aSuccessfully set {gamerule} to {value} in {world}.
 mv-core.gamerule.success.multiple=&aSuccessfully set {gamerule} to {value} in {count} worlds.
 
@@ -64,14 +64,14 @@ mv-core.import.name.description=Name of the world folder.
 mv-core.import.env.description=The world's environment. See: /mv env
 mv-core.import.other.description=Other world settings. See: https://gg.gg/nn8c2
 mv-core.import.importing=Starting import of world '{world}'...
-mv-core.import.failed=&cFailed! &fSee console for more details.
+mv-core.import.failed=Failed! &fSee console for more details.
 mv-core.import.success=&aComplete!
 
 # /mv load
 mv-core.load.description=Loads a world. World must be already in worlds.yml, else please use /mv import.
 mv-core.load.world.description=Name of world you want to load.
 mv-core.load.loading=Loading world '{world}'...
-mv-core.load.failed=&cError trying to load world '{world}'!
+mv-core.load.failed=Error trying to load world '{world}'!
 mv-core.load.success=&aLoaded world '{world}'!
 
 # /mv regen
@@ -79,7 +79,7 @@ mv-core.regen.description=Regenerates a world on your server. The previous state
 mv-core.regen.world.description=World that you want to regen.
 mv-core.regen.other.description=Other world settings. See: http://gg.gg/nn8lk
 mv-core.regen.regenerating=Regenerating world '{world}'...
-mv-core.regen.failed=&cThere was an issue regenerating '{world}'! &fPlease check console for errors.
+mv-core.regen.failed=There was an issue regenerating '{world}'! &fPlease check console for errors.
 mv-core.regen.success=&aWorld {world} was regenerated!
 mv-core.regen.prompt=Are you sure you want to regenerate world '{world}'?
 
@@ -91,7 +91,7 @@ mv-core.reload.success=&aReload complete!
 # /mv remove
 mv-core.remove.description=Unloads a world from Multiverse and removes it from worlds.yml. This does NOT delete the world folder.
 mv-core.remove.world.description=World you want to remove from MV's knowledge.
-mv-core.remove.failed=&cError trying to remove world from config!
+mv-core.remove.failed=Error trying to remove world from config!
 mv-core.remove.success=&aWorld '{world}' is removed from config!
 
 # /mv
@@ -108,7 +108,7 @@ mv-core.teleport.success=Teleporting {player} to {destination}...
 mv-core.unload.description=Unloads a world from Multiverse. This does NOT remove the world folder. This does NOT remove it from the config file.
 mv-core.unload.world.description=Name of the world you want to unload.
 mv-core.unload.unloading=Unloading world '{world}'...
-mv-core.unload.failure=&cError unloading world '{world}'! &fSee console for more details.
+mv-core.unload.failure=Error unloading world '{world}'! &fSee console for more details.
 mv-core.unload.success=&aUnloaded world '{world}'!
 
 # /mv usage


### PR DESCRIPTION
More work to do in other places, but this makes all the current commands use ACF's i18n features.
Other places need this conversion done as well, such as `MVCommandConditions` (has hard-coded plain English exceptions) and legacy classes (pending rewrites in many cases as-is).