### PR TITLE
Do not migrate if new config file is created

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/configuration/handle/FileConfigHandle.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/configuration/handle/FileConfigHandle.java
@@ -34,15 +34,21 @@ abstract class FileConfigHandle<C extends FileConfiguration> extends GenericConf
      */
     @Override
     public boolean load() {
-        if (!createConfigFile()) {
+        boolean newFileCreated;
+        try {
+            newFileCreated = createConfigFile();
+        } catch (IOException e) {
             Logging.severe("Failed to create config file: %s", configFile.getName());
+            Logging.severe(e.getMessage());
             return false;
         }
         if (!loadConfigObject()) {
             Logging.severe("Failed to load config file: %s", configFile.getName());
             return false;
         }
-        migrateConfig();
+        if (!newFileCreated) {
+            migrateConfig();
+        }
         setUpNodes();
         return true;
     }
@@ -52,19 +58,11 @@ abstract class FileConfigHandle<C extends FileConfiguration> extends GenericConf
      *
      * @return True if file exist or created successfully, otherwise false.
      */
-    protected boolean createConfigFile() {
+    protected boolean createConfigFile() throws IOException {
         if (configFile.exists()) {
-            return true;
-        }
-        try {
-            if (!configFile.createNewFile()) {
-                return false;
-            }
-            Logging.info("Created new config file: %s", configFile.getName());
-        } catch (IOException e) {
             return false;
         }
-        return true;
+        return configFile.createNewFile();
     }
 
     /**


### PR DESCRIPTION
Bcu it defaults to version 0, trying to migrate from an empty new config file will mess up default values. Hence I added a check to prevent migration if the config file is newly created.