### PR TITLE
Added option to disable saving of source world when cloning.

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCoreConfiguration.java
@@ -77,6 +77,8 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     private volatile boolean autopurge;
     @Property
     private volatile boolean idonotwanttodonate;
+    @Property
+    private volatile boolean clone_saving;
 
     public MultiverseCoreConfiguration() {
         super();
@@ -111,6 +113,7 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
         portalsearchradius = 128;
         autopurge = true;
         idonotwanttodonate = false;
+        clone_saving=false;
         // END CHECKSTYLE-SUPPRESSION: MagicNumberCheck
     }
 
@@ -376,6 +379,16 @@ public class MultiverseCoreConfiguration extends SerializationConfig implements 
     @Override
     public boolean isShowingDonateMessage() {
         return !idonotwanttodonate;
+    }
+
+    @Override
+    public boolean doCloneSaving(){
+        return clone_saving;
+    }
+
+    @Override
+    public void setCloneSaving(boolean doSaving){
+        this.clone_saving=doSaving;
     }
 
     @Override

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MVWorldManager.java
@@ -25,7 +25,9 @@ import java.util.List;
  * This API contains all of the world managing
  * functions that your heart desires!
  */
-public interface MVWorldManager {
+public interface
+
+MVWorldManager {
     /**
      * Add a new World to the Multiverse Setup.
      *

--- a/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/api/MultiverseCoreConfig.java
@@ -233,6 +233,10 @@ public interface MultiverseCoreConfig extends ConfigurationSerializable {
      */
     boolean isShowingDonateMessage();
 
+    boolean doCloneSaving();
+
+    void setCloneSaving(boolean doSaving);
+
     /**
      * Sets whether or not the donation/patreon messages are shown.
      *

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -176,9 +176,11 @@ public class WorldManager implements MVWorldManager {
         boolean wasAutoSave = false;
         if (oldWorld != null && oldWorld.getCBWorld().isAutoSave()) {
             wasAutoSave = true;
-            Logging.config("Saving world '%s'", oldName);
-            oldWorld.getCBWorld().setAutoSave(false);
-            oldWorld.getCBWorld().save();
+            if(plugin.getMVConfig().doCloneSaving()){
+                Logging.config("Saving world '%s'", oldName);
+                oldWorld.getCBWorld().setAutoSave(false);
+                oldWorld.getCBWorld().save();
+            }
         }
         Logging.config("Copying files for world '%s'", oldName);
         if (!FileUtils.copyFolder(oldWorldFile, newWorldFile, ignoreFiles)) {


### PR DESCRIPTION
Hello I have never contributed to multiverse before, but I use your plugin as a dependency for my minecraft minigame server. I often clone a template world to open an arena world. Whenever this occurred the server would take a TPS drop. It appears it was from the source world being forcibly saved - though my server was already configured to autosave worlds.

I made a fork to make this saving a configurable operation. If you'd like to incorporate it, here it is.