### PR TITLE
Internal Chunk Generators and multiverse:void generator as first custom gen. VOID as Environment type when creating or importing worlds. 

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/MultiverseCore.java
@@ -78,6 +78,7 @@ import com.onarandombox.MultiverseCore.destination.PlayerDestination;
 import com.onarandombox.MultiverseCore.destination.WorldDestination;
 import com.onarandombox.MultiverseCore.event.MVDebugModeEvent;
 import com.onarandombox.MultiverseCore.event.MVVersionEvent;
+import com.onarandombox.MultiverseCore.generators.InternalChunkGeneratorManager;
 import com.onarandombox.MultiverseCore.listeners.MVAsyncPlayerChatListener;
 import com.onarandombox.MultiverseCore.listeners.MVChatListener;
 import com.onarandombox.MultiverseCore.listeners.MVEntityListener;
@@ -281,6 +282,11 @@ public class MultiverseCore extends JavaPlugin implements MVPlugin, Core {
 
         this.messaging = new MVMessaging();
         this.economist = new MVEconomist(this);
+        //CustomGenerators start
+        // Initialize internal chunk generator manager
+        InternalChunkGeneratorManager.init();
+        //CustomGenerators end
+
         // Load the defaultWorldGenerators
         this.worldManager.getDefaultWorldGenerators();
 

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/CreateCommand.java
@@ -90,6 +90,12 @@ public class CreateCommand extends MultiverseCommand {
             return;
         }
 
+        //CustomGenerators start
+        if(env.equalsIgnoreCase("VOID")) {
+            env = "NORMAL";
+            generator = "multiverse:void";
+        }
+        //CustomGenerators end
         Environment environment = EnvironmentCommand.getEnvFromString(env);
         if (environment == null) {
             sender.sendMessage(ChatColor.RED + "That is not a valid environment.");
@@ -100,7 +106,12 @@ public class CreateCommand extends MultiverseCommand {
         // If they didn't specify a type, default to NORMAL
         if (typeString == null) {
             typeString = "NORMAL";
+        //CustomGenerators start
+        } else if(typeString.equalsIgnoreCase("VOID")) {
+            typeString = "NORMAL";
+            generator = "multiverse:void";
         }
+        //CustomGenerators end
         WorldType type = EnvironmentCommand.getWorldTypeFromString(typeString);
         if (type == null) {
             sender.sendMessage(ChatColor.RED + "That is not a valid World Type.");
@@ -108,6 +119,7 @@ public class CreateCommand extends MultiverseCommand {
             return;
         }
         // Determine if the generator is valid. #918
+
         if (generator != null) {
             List<String> genarray = new ArrayList<String>(Arrays.asList(generator.split(":")));
             if (genarray.size() < 2) {

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/EnvironmentCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/EnvironmentCommand.java
@@ -45,6 +45,9 @@ public class EnvironmentCommand extends MultiverseCommand {
         sender.sendMessage(ChatColor.GREEN + "NORMAL");
         sender.sendMessage(ChatColor.RED + "NETHER");
         sender.sendMessage(ChatColor.AQUA + "END");
+        //CustomGenerators start
+        sender.sendMessage(ChatColor.WHITE + "VOID");
+        //CustomGenerators end
     }
     /**
      * Shows all valid known world types to a {@link CommandSender}.

--- a/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/commands/ImportCommand.java
@@ -106,12 +106,19 @@ public class ImportCommand extends MultiverseCommand {
         }
 
         String env = args.get(1);
+        //CustomGenerators start
+        if(env.equalsIgnoreCase("VOID")){
+            env = "NORMAL";
+            generator = "multiverse:void";
+        }
+        //CustomGenerators end
         Environment environment = EnvironmentCommand.getEnvFromString(env);
         if (environment == null) {
             sender.sendMessage(ChatColor.RED + "That is not a valid environment.");
             EnvironmentCommand.showEnvironments(sender);
             return;
         }
+
 
         if (!worldFile.exists()) {
             sender.sendMessage(ChatColor.RED + "FAILED.");

--- a/src/main/java/com/onarandombox/MultiverseCore/generators/InternalChunkGeneratorManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/generators/InternalChunkGeneratorManager.java
@@ -1,0 +1,43 @@
+package com.onarandombox.MultiverseCore.generators;
+
+import com.onarandombox.MultiverseCore.generators.impl.MultiverseVoidGenerator;
+import org.bukkit.generator.ChunkGenerator;
+
+import java.util.Map;
+
+//CustomGenerators start
+public class InternalChunkGeneratorManager {
+
+    private final Map<String, ChunkGenerator> generators;
+
+    private static InternalChunkGeneratorManager instance;
+
+    public static InternalChunkGeneratorManager get() {
+        if (instance == null) {
+            throw new IllegalStateException("InternalChunkGeneratorManager has not been initialized yet.");
+        }
+        return instance;
+    }
+
+    public static void init(){
+        new InternalChunkGeneratorManager();
+    }
+
+    public InternalChunkGeneratorManager() {
+        instance = this;
+        //register internal generators instances (singleton)
+        generators = Map.of(
+                "VOID", new MultiverseVoidGenerator()
+        );
+    }
+
+    public boolean exists(String generator){
+        return generators.containsKey(generator);
+    }
+
+    public ChunkGenerator getGenerator(String generator){
+        return generators.getOrDefault(generator.toUpperCase(), null);
+    }
+
+}
+//CustomGenerators end

--- a/src/main/java/com/onarandombox/MultiverseCore/generators/impl/MultiverseVoidGenerator.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/generators/impl/MultiverseVoidGenerator.java
@@ -1,0 +1,22 @@
+package com.onarandombox.MultiverseCore.generators.impl;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.generator.ChunkGenerator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Random;
+
+public class MultiverseVoidGenerator extends ChunkGenerator {
+
+    @Override
+    public @NotNull ChunkData generateChunkData(@NotNull World world, @NotNull Random random, int x, int z, @NotNull ChunkGenerator.BiomeGrid biome) {
+        return createChunkData(world);
+    }
+
+    @Override
+    public @Nullable Location getFixedSpawnLocation(@NotNull World world, @NotNull Random random) {
+        return new Location(world,0, 64, 0);
+    }
+}

--- a/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
+++ b/src/main/java/com/onarandombox/MultiverseCore/utils/WorldManager.java
@@ -17,6 +17,7 @@ import com.onarandombox.MultiverseCore.api.MultiverseWorld;
 import com.onarandombox.MultiverseCore.api.SafeTTeleporter;
 import com.onarandombox.MultiverseCore.api.WorldPurger;
 import com.onarandombox.MultiverseCore.event.MVWorldDeleteEvent;
+import com.onarandombox.MultiverseCore.generators.InternalChunkGeneratorManager;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.Location;
@@ -257,7 +258,12 @@ public class WorldManager implements MVWorldManager {
 
         // TODO: Use the fancy kind with the commandSender
         if (generator != null && generator.length() != 0) {
-            c.generator(generator);
+            //CustomGenerators start
+            if(generator.startsWith("multiverse:"))
+                c.generator(InternalChunkGeneratorManager.get().getGenerator(generator.split(":")[1]));
+            else
+                c.generator(generator);
+            //CustomGenerators end
         }
         c.environment(env);
         if (type != null) {
@@ -305,7 +311,11 @@ public class WorldManager implements MVWorldManager {
         if (generator == null) {
             return null;
         }
-
+        //CustomGenerators start
+        if(generator.equalsIgnoreCase("multiverse")){
+            return InternalChunkGeneratorManager.get().getGenerator(generatorID);
+        }
+        //CustomGenerators end
         final Plugin myPlugin = this.plugin.getServer().getPluginManager().getPlugin(generator);
         if (myPlugin == null) {
             return null;


### PR DESCRIPTION
Implemented internal Chunk generators. Now multiverse can have its own custom chunk generators. Implemented the void generator (very useful). Added world type "VOID" in environments list. When create or import a world with type VOID the world will be added as a NORMAL world with "multiverse:void" generator.