### PR TITLE
Implement more customisable way of doing permission checking

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/commands/TeleportCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/TeleportCommand.java
@@ -2,7 +2,6 @@ package org.mvplugins.multiverse.core.commands;
 
 import java.util.List;
 
-import co.aikar.commands.CommandIssuer;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
@@ -78,10 +77,5 @@ class TeleportCommand extends CoreCommand {
                     Logging.severe("Error while teleporting %s to %s: %s",
                             playerName, destination, throwable.getMessage());
                 });
-    }
-
-    @Override
-    public boolean hasPermission(CommandIssuer issuer) {
-        return permissionsChecker.hasAnyTeleportPermission(issuer.getIssuer());
     }
 }

--- a/src/main/java/org/mvplugins/multiverse/core/commands/TeleportCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/TeleportCommand.java
@@ -5,6 +5,7 @@ import java.util.List;
 import co.aikar.commands.CommandIssuer;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Flags;
 import co.aikar.commands.annotation.Subcommand;
@@ -41,6 +42,7 @@ class TeleportCommand extends CoreCommand {
 
     @CommandAlias("mvtp")
     @Subcommand("teleport|tp")
+    @CommandPermission("@teleport")
     @CommandCompletion("@players|@mvworlds:playerOnly|@destinations:playerOnly @mvworlds|@destinations")
     @Syntax("[player] <destination>")
     @Description("{@@mv-core.teleport.description}")

--- a/src/main/java/org/mvplugins/multiverse/core/commands/TeleportCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/TeleportCommand.java
@@ -41,7 +41,7 @@ class TeleportCommand extends CoreCommand {
 
     @CommandAlias("mvtp")
     @Subcommand("teleport|tp")
-    @CommandPermission("@teleport")
+    @CommandPermission("@mvteleport")
     @CommandCompletion("@players|@mvworlds:playerOnly|@destinations:playerOnly @mvworlds|@destinations")
     @Syntax("[player] <destination>")
     @Description("{@@mv-core.teleport.description}")

--- a/src/main/java/org/mvplugins/multiverse/core/commandtools/MVCommandManager.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commandtools/MVCommandManager.java
@@ -2,11 +2,10 @@ package org.mvplugins.multiverse.core.commandtools;
 
 import java.util.List;
 
-import co.aikar.commands.BukkitCommandCompletionContext;
-import co.aikar.commands.BukkitCommandExecutionContext;
 import co.aikar.commands.CommandCompletions;
 import co.aikar.commands.CommandContexts;
 import co.aikar.commands.CommandHelp;
+import co.aikar.commands.CommandIssuer;
 import co.aikar.commands.HelpEntry;
 import co.aikar.commands.PaperCommandManager;
 import jakarta.inject.Inject;
@@ -32,6 +31,7 @@ public class MVCommandManager extends PaperCommandManager {
     private final CommandQueueManager commandQueueManager;
     private final Provider<MVCommandContexts> commandContextsProvider;
     private final Provider<MVCommandCompletions> commandCompletionsProvider;
+    private final MVCommandPermissions commandPermissions;
 
     @Inject
     MVCommandManager(
@@ -41,12 +41,14 @@ public class MVCommandManager extends PaperCommandManager {
             @NotNull Provider<MVCommandContexts> commandContextsProvider,
             @NotNull Provider<MVCommandCompletions> commandCompletionsProvider,
             @NotNull WorldManager worldManager,
-            @NotNull WorldNameChecker worldNameChecker) {
+            @NotNull WorldNameChecker worldNameChecker,
+            @NotNull MVCommandPermissions commandPermissions) {
         super(plugin);
         this.flagsManager = flagsManager;
         this.commandQueueManager = commandQueueManager;
         this.commandContextsProvider = commandContextsProvider;
         this.commandCompletionsProvider = commandCompletionsProvider;
+        this.commandPermissions = commandPermissions;
 
         MVCommandConditions.load(this, worldManager, worldNameChecker);
         this.enableUnstableAPI("help");
@@ -85,6 +87,10 @@ public class MVCommandManager extends PaperCommandManager {
         return commandQueueManager;
     }
 
+    public synchronized @NotNull MVCommandPermissions getCommandPermissions() {
+        return commandPermissions;
+    }
+
     /**
      * Gets class responsible for parsing string args into objects.
      *
@@ -109,6 +115,11 @@ public class MVCommandManager extends PaperCommandManager {
             this.completions = commandCompletionsProvider.get();
         }
         return (MVCommandCompletions) this.completions;
+    }
+
+    @Override
+    public boolean hasPermission(CommandIssuer issuer, String permission) {
+        return commandPermissions.hasPermission(issuer, permission);
     }
 
     /**

--- a/src/main/java/org/mvplugins/multiverse/core/commandtools/MVCommandPermissions.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commandtools/MVCommandPermissions.java
@@ -1,0 +1,39 @@
+package org.mvplugins.multiverse.core.commandtools;
+
+import co.aikar.commands.CommandIssuer;
+import io.vavr.control.Option;
+import jakarta.inject.Inject;
+import org.jetbrains.annotations.NotNull;
+import org.jvnet.hk2.annotations.Service;
+import org.mvplugins.multiverse.core.permissions.CorePermissionsChecker;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Predicate;
+
+@Service
+public class MVCommandPermissions {
+    private final Map<String, Predicate<CommandIssuer>> permissionsCheckMap;
+
+    @Inject
+    MVCommandPermissions(@NotNull CorePermissionsChecker permissionsChecker) {
+        permissionsCheckMap = new HashMap<>();
+
+        registerPermissionChecker("teleport", issuer -> permissionsChecker.hasAnyTeleportPermission(issuer.getIssuer()));
+    }
+
+    public void registerPermissionChecker(String id, Predicate<CommandIssuer> checker) {
+        permissionsCheckMap.put(prepareId(id), checker);
+    }
+
+    private static @NotNull String prepareId(String id) {
+        return (id.startsWith("@") ? "" : "@") + id.toLowerCase(Locale.ENGLISH);
+    }
+
+    public boolean hasPermission(CommandIssuer issuer, String permission) {
+        return Option.of(permissionsCheckMap.get(permission))
+                .map(checker -> checker.test(issuer))
+                .getOrElse(() -> issuer.hasPermission(permission));
+    }
+}

--- a/src/main/java/org/mvplugins/multiverse/core/commandtools/MVCommandPermissions.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commandtools/MVCommandPermissions.java
@@ -1,6 +1,7 @@
 package org.mvplugins.multiverse.core.commandtools;
 
 import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.annotation.CommandPermission;
 import io.vavr.control.Option;
 import jakarta.inject.Inject;
 import org.jetbrains.annotations.NotNull;
@@ -12,6 +13,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 
+/**
+ * Maps permission checking to custom logic for commands, to allow more complex permission checking.
+ */
 @Service
 public class MVCommandPermissions {
     private final Map<String, Predicate<CommandIssuer>> permissionsCheckMap;
@@ -20,9 +24,17 @@ public class MVCommandPermissions {
     MVCommandPermissions(@NotNull CorePermissionsChecker permissionsChecker) {
         permissionsCheckMap = new HashMap<>();
 
-        registerPermissionChecker("teleport", issuer -> permissionsChecker.hasAnyTeleportPermission(issuer.getIssuer()));
+        registerPermissionChecker("mvteleport", issuer -> permissionsChecker.hasAnyTeleportPermission(issuer.getIssuer()));
+        registerPermissionChecker("mvspawn", issuer -> permissionsChecker.hasAnySpawnPermission(issuer.getIssuer()));
     }
 
+    /**
+     * Registers a custom permission checker callback. Use `@id-name` in {@link CommandPermission} decorator to use
+     * the callback instead of the default permission string checking.
+     *
+     * @param id         The permission id
+     * @param checker    The permission checker callback
+     */
     public void registerPermissionChecker(String id, Predicate<CommandIssuer> checker) {
         permissionsCheckMap.put(prepareId(id), checker);
     }
@@ -31,7 +43,13 @@ public class MVCommandPermissions {
         return (id.startsWith("@") ? "" : "@") + id.toLowerCase(Locale.ENGLISH);
     }
 
-    public boolean hasPermission(CommandIssuer issuer, String permission) {
+    /**
+     * Check if the issuer has the given permission.
+     * @param issuer        The issuer
+     * @param permission    The permission to check
+     * @return True if the issuer has the permission
+     */
+    boolean hasPermission(CommandIssuer issuer, String permission) {
         return Option.of(permissionsCheckMap.get(permission))
                 .map(checker -> checker.test(issuer))
                 .getOrElse(() -> issuer.hasPermission(permission));

--- a/src/main/java/org/mvplugins/multiverse/core/permissions/CorePermissions.java
+++ b/src/main/java/org/mvplugins/multiverse/core/permissions/CorePermissions.java
@@ -26,6 +26,11 @@ final class CorePermissions {
      */
     static final String TELEPORT = "multiverse.teleport";
 
+    /**
+     * Permission to teleport to spawn in a world.
+     */
+    static final String SPAWN = "multiverse.core.spawn";
+
     private CorePermissions() {
         // Prevent instantiation as this is a static utility class
     }

--- a/src/main/java/org/mvplugins/multiverse/core/permissions/CorePermissionsChecker.java
+++ b/src/main/java/org/mvplugins/multiverse/core/permissions/CorePermissionsChecker.java
@@ -40,6 +40,39 @@ public class CorePermissionsChecker {
     }
 
     /**
+     * Checks if the teleporter has permission to teleport the teleportee to the world's spawnpoint.
+     *
+     * @param teleporter    The teleporter.
+     * @param teleportee    The teleportee.
+     * @param world         The world.
+     * @return True if the teleporter has permission, false otherwise.
+     */
+    public boolean hasSpawnPermission(
+            @NotNull CommandSender teleporter,
+            @NotNull Entity teleportee,
+            @NotNull LoadedMultiverseWorld world) {
+        String permission = concatPermission(CorePermissions.SPAWN, teleportee.equals(teleporter) ? "self" : "other");
+        if (!hasPermission(teleporter, permission)) {
+            return false;
+        }
+        // TODO: Config whether to use finer permission
+        return hasPermission(teleporter, concatPermission(permission, world.getName()));
+    }
+
+    /**
+     * Check if the issuer has any base spawn permission of `multiverse.core.spawn.self` or `multiverse.core.spawn.other`
+     *
+     * @param sender    The sender that ran the command
+     * @return True if the sender has any base spawn permission.
+     */
+    public boolean hasAnySpawnPermission(@NotNull CommandSender sender) {
+        if (hasPermission(sender, concatPermission(CorePermissions.SPAWN, "self"))) {
+            return true;
+        }
+        return hasPermission(sender, concatPermission(CorePermissions.SPAWN, "other"));
+    }
+
+    /**
      * Checks if the teleporter has permission to teleport the teleportee to the destination.
      *
      * @param teleporter    The teleporter.


### PR DESCRIPTION
This fixes the issue of `/mv tp` and `/mv spawn` auto completing even tho user does not have permission. Bcu we cant just use static string as the permissions are quite complex

<!-- artifact-comment-section 3137 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3137](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/12272029981/multiverse-core-pr3137.zip)

<!-- artifact-comment-section 3137 end (DO NOT EDIT ABOVE) -->