### PR TITLE
`/mv who` command auto world

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/commands/WhoCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/WhoCommand.java
@@ -69,6 +69,7 @@ public class WhoCommand extends CoreCommand {
         this.worldManager = worldManager;
     }
 
+    @CommandAlias("mvwhoall")
     @Subcommand("whoall")
     @CommandPermission("multiverse.core.list.who.all")
     @CommandCompletion("@flags:groupName=mvwhocommand")
@@ -93,6 +94,7 @@ public class WhoCommand extends CoreCommand {
 
     }
 
+    @CommandAlias("mvwho")
     @Subcommand("who")
     @CommandPermission("multiverse.core.list.who")
     @CommandCompletion("@mvworlds:scope=both @flags:groupName=mvwhocommand")
@@ -101,6 +103,7 @@ public class WhoCommand extends CoreCommand {
     void onWhoCommand(
             MVCommandIssuer issuer,
 
+            @Optional
             @Syntax("<world>")
             @Description("{@@mv-core.who.world.description}")
             LoadedMultiverseWorld inputtedWorld,
@@ -110,6 +113,10 @@ public class WhoCommand extends CoreCommand {
             @Description("{@@mv-core.who.flags.description}")
             String[] flags) {
         ParsedCommandFlags parsedFlags = parseFlags(flags);
+
+        if (inputtedWorld == null) {
+            inputtedWorld = worldManager.getLoadedWorld(issuer.getPlayer().getWorld()).getOrNull(); // TODO: Deal with it not being a MV world
+        }
 
         // Send the display
         getListDisplay(

--- a/src/main/java/org/mvplugins/multiverse/core/commands/WhoCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/WhoCommand.java
@@ -5,6 +5,7 @@ import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Flags;
 import co.aikar.commands.annotation.Optional;
 import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
@@ -102,7 +103,7 @@ public class WhoCommand extends CoreCommand {
     @Description("{@@mv-core.who.description}")
     void onWhoCommand(
             MVCommandIssuer issuer,
-
+            @Flags("resolve=issuerAware")
             @Optional
             @Syntax("<world>")
             @Description("{@@mv-core.who.world.description}")
@@ -113,10 +114,6 @@ public class WhoCommand extends CoreCommand {
             @Description("{@@mv-core.who.flags.description}")
             String[] flags) {
         ParsedCommandFlags parsedFlags = parseFlags(flags);
-
-        if (inputtedWorld == null) {
-            inputtedWorld = worldManager.getLoadedWorld(issuer.getPlayer().getWorld()).getOrNull(); // TODO: Deal with it not being a MV world
-        }
 
         // Send the display
         getListDisplay(

--- a/src/main/java/org/mvplugins/multiverse/core/commands/WhoCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/WhoCommand.java
@@ -94,7 +94,7 @@ public class WhoCommand extends CoreCommand {
 
     }
 
-    @CommandAlias("mvwho")
+    @CommandAlias("mvwho|mvw")
     @Subcommand("who")
     @CommandPermission("multiverse.core.list.who")
     @CommandCompletion("@mvworlds:scope=both @flags:groupName=mvwhocommand")


### PR DESCRIPTION
Sets the world for `/mv who` to the player's world if it is not specified

<!-- artifact-comment-section 3157 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3157](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/12871129185/multiverse-core-pr3157.zip)

<!-- artifact-comment-section 3157 end (DO NOT EDIT ABOVE) -->