### PR TITLE
Fix completion for `/mvremove <world> [flags]`

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/commands/RemoveCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/RemoveCommand.java
@@ -51,7 +51,7 @@ final class RemoveCommand extends CoreCommand {
     @CommandAlias("mvremove")
     @Subcommand("remove")
     @CommandPermission("multiverse.core.remove")
-    @CommandCompletion("@mvworlds:scope=both")
+    @CommandCompletion("@mvworlds:scope=loaded @flags:groupName=mvremovecommand")
     @Syntax("<world>")
     @Description("{@@mv-core.remove.description}")
     void onRemoveCommand(


### PR DESCRIPTION
Still errors with command conditions when tab completing an unloaded world, but there aren't any command conditions on `/mvremove`... At least it doesn't error whenever you try using a flag now!

<!-- artifact-comment-section 3171 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3171](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/13354672310/multiverse-core-pr3171.zip)

<!-- artifact-comment-section 3171 end (DO NOT EDIT ABOVE) -->