### PR TITLE
Add back legacy gamerule commands

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/commands/GameruleCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/GameruleCommand.java
@@ -54,6 +54,7 @@ final class GameruleCommand extends CoreCommand {
         super(commandManager);
     }
 
+    @CommandAlias("mvrule|mvgamerule")
     @Subcommand("set")
     @CommandPermission("multiverse.core.gamerule.set")
     @CommandCompletion("@gamerules @gamerulesvalues @mvworlds:multiple|*")
@@ -145,6 +146,7 @@ final class GameruleCommand extends CoreCommand {
         }
     }
 
+    @CommandAlias("mvrules|mvgamerules")
     @Subcommand("list")
     @CommandPermission("multiverse.core.gamerule.list")
     @CommandCompletion("@mvworlds|@flags:groupName=mvgamerulecommand @flags:groupName=mvgamerulecommand")


### PR DESCRIPTION
Adds back `/mvgamerule` and `/mvrule` for `/mv gamerule set` as well as `/mvgamerules` and `/mvrule` for `/mv gamerule list`

<!-- artifact-comment-section 3172 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3172](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/13354994580/multiverse-core-pr3172.zip)

<!-- artifact-comment-section 3172 end (DO NOT EDIT ABOVE) -->