### PR TITLE
Fix who command null exception when invalid world is specified

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/commands/WhoCommand.java
+++ b/src/main/java/org/mvplugins/multiverse/core/commands/WhoCommand.java
@@ -79,7 +79,6 @@ class WhoCommand extends CoreCommand {
     void onWhoCommand(
             MVCommandIssuer issuer,
             @Flags("resolve=issuerAware")
-            @Optional
             @Syntax("<world>")
             @Description("{@@mv-core.who.world.description}")
             LoadedMultiverseWorld inputtedWorld,


### PR DESCRIPTION
Fixes #3198

<!-- artifact-comment-section 3200 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3200](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/14751808602/multiverse-core-pr3200.zip)

<!-- artifact-comment-section 3200 end (DO NOT EDIT ABOVE) -->