### PR TITLE
Fix clone command test due to World#save being unimplemented

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/world/options/CloneWorldOptions.java
+++ b/src/main/java/org/mvplugins/multiverse/core/world/options/CloneWorldOptions.java
@@ -120,11 +120,11 @@ public final class CloneWorldOptions implements KeepWorldSettingsOptions {
     /**
      * Sets whether to save the world to disk before clone copying.
      *
-     * @param forceSaveInput Whether to save the world to disk before clone copying.
+     * @param saveBukkitWorldInput Whether to save the world to disk before clone copying.
      * @return This {@link CloneWorldOptions} instance.
      */
-    public @NotNull CloneWorldOptions saveBukkitWorld(boolean forceSaveInput) {
-        this.saveBukkitWorld = forceSaveInput;
+    public @NotNull CloneWorldOptions saveBukkitWorld(boolean saveBukkitWorldInput) {
+        this.saveBukkitWorld = saveBukkitWorldInput;
         return this;
     }
 

--- a/src/test/java/org/mvplugins/multiverse/core/world/WorldManagerTest.kt
+++ b/src/test/java/org/mvplugins/multiverse/core/world/WorldManagerTest.kt
@@ -178,7 +178,7 @@ class WorldManagerTest : TestWithMockBukkit() {
 
     @Test
     fun `Clone world`() {
-        assertTrue(worldManager.cloneWorld(CloneWorldOptions.fromTo(world, "cloneworld")).isSuccess)
+        assertTrue(worldManager.cloneWorld(CloneWorldOptions.fromTo(world, "cloneworld").saveBukkitWorld(false)).isSuccess)
         val getWorld = worldManager.getLoadedWorld("cloneworld")
         assertTrue(getWorld.isDefined)
         val world = getWorld.get()


### PR DESCRIPTION


<!-- artifact-comment-section 3214 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3214](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/14809424056/multiverse-core-pr3214.zip)

<!-- artifact-comment-section 3214 end (DO NOT EDIT ABOVE) -->