### PR TITLE
Fix incorrect way of unregistering MultiverseCoreApi from service manager

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/MultiverseCoreApi.java
+++ b/src/main/java/org/mvplugins/multiverse/core/MultiverseCoreApi.java
@@ -33,8 +33,8 @@ public class MultiverseCoreApi {
     }
 
     static void shutdown() {
+        Bukkit.getServicesManager().unregister(instance);
         instance = null;
-        Bukkit.getServicesManager().unregister(MultiverseCoreApi.class);
     }
 
     /**


### PR DESCRIPTION


<!-- artifact-comment-section 3217 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3217](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/14810765292/multiverse-core-pr3217.zip)

<!-- artifact-comment-section 3217 end (DO NOT EDIT ABOVE) -->