### PR TITLE
Fix adventure dep in spigot-based server

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/utils/text/ChatTextFormatter.java
+++ b/src/main/java/org/mvplugins/multiverse/core/utils/text/ChatTextFormatter.java
@@ -18,7 +18,8 @@ public final class ChatTextFormatter {
     private static final TextFormatter wrapper;
 
     static {
-        if (ReflectHelper.hasClass("net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer")) {
+        if (ReflectHelper.hasClass("net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer")
+         && ReflectHelper.hasClass("net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer")) {
             wrapper = new AdventureTextFormatter();
         } else {
             wrapper = new ChatColorTextFormatter();


### PR DESCRIPTION
From https://github.com/MrXiaoM/SweetMail/issues/51

As you see, Multiverse-Core can not works with my plugin SweetMail in a spigot-based server called `arclight`, which with no `adventure` defaultly.
My plugin SweetMail will adds the four dependencies below into my plugin classloader:
+ `net.kyori:adventure-api:4.22.0`
+ `net.kyori:adventure-platform-bukkit:4.4.0`
+ `net.kyori:adventure-text-serializer-gson:4.22.0`
+ `net.kyori:adventure-text-minimessage:4.22.0`

Multiverse-Core certainly can't find `net/kyori/adventure/text/serializer/plain/PlainTextComponentSerializer` in this situation because my plugin don't need it.

So we should check that is `PlainTextComponentSerializer` exists too.