### PR TITLE
fix spawn location angle

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/world/WorldConfigNodes.java
+++ b/src/main/java/org/mvplugins/multiverse/core/world/WorldConfigNodes.java
@@ -238,7 +238,7 @@ final class WorldConfigNodes {
                 if (!(world instanceof LoadedMultiverseWorld loadedWorld)) return;
                 if (newValue == null || newValue instanceof NullSpawnLocation) return;
                 loadedWorld.getBukkitWorld().peek(bukkitWorld -> {
-                    bukkitWorld.setSpawnLocation(newValue.getBlockX(), newValue.getBlockY(), newValue.getBlockZ(), newValue.getYaw());
+                    bukkitWorld.setSpawnLocation(newValue);
                     newValue.setWorld(bukkitWorld);
                 });
             }));


### PR DESCRIPTION
Currently, Multiverse-Core ignores the world spawn angle and always defaults to 0.0.