### PR TITLE
Configurable server.properties path

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/config/CoreConfig.java
+++ b/src/main/java/org/mvplugins/multiverse/core/config/CoreConfig.java
@@ -623,10 +623,12 @@ public final class CoreConfig {
         return configHandle.get(configNodes.bukkitYmlPath);
     }
 
+    @ApiStatus.AvailableSince("5.3")
     public Try<Void> setServerPropertiesPath(String serverPropertiesPath) {
         return configHandle.set(configNodes.serverPropertiesPath, serverPropertiesPath);
     }
 
+    @ApiStatus.AvailableSince("5.3")
     public String getServerPropertiesPath() {
         return configHandle.get(configNodes.serverPropertiesPath);
     }

--- a/src/main/java/org/mvplugins/multiverse/core/config/CoreConfig.java
+++ b/src/main/java/org/mvplugins/multiverse/core/config/CoreConfig.java
@@ -623,6 +623,14 @@ public final class CoreConfig {
         return configHandle.get(configNodes.bukkitYmlPath);
     }
 
+    public Try<Void> setServerPropertiesPath(String serverPropertiesPath) {
+        return configHandle.set(configNodes.serverPropertiesPath, serverPropertiesPath);
+    }
+
+    public String getServerPropertiesPath() {
+        return configHandle.get(configNodes.serverPropertiesPath);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/org/mvplugins/multiverse/core/config/CoreConfigNodes.java
+++ b/src/main/java/org/mvplugins/multiverse/core/config/CoreConfigNodes.java
@@ -512,6 +512,13 @@ final class CoreConfigNodes {
             .name("bukkit-yml-path")
             .build());
 
+    final ConfigNode<String> serverPropertiesPath = node(ConfigNode.builder("misc.server-properties-path", String.class)
+            .comment("Change this if you use a custom path for the server.properties file with `--config` startup flag.")
+            .comment("Note: this config option needs a server restart to take effect.")
+            .defaultValue("server.properties")
+            .name("server-properties-path")
+            .build());
+
     final ConfigNode<Integer> globalDebug = node(ConfigNode.builder("misc.global-debug", Integer.class)
             .comment("")
             .comment("This is our debug flag to help identify issues with Multiverse.")

--- a/src/main/java/org/mvplugins/multiverse/core/config/CoreConfigNodes.java
+++ b/src/main/java/org/mvplugins/multiverse/core/config/CoreConfigNodes.java
@@ -513,6 +513,7 @@ final class CoreConfigNodes {
             .build());
 
     final ConfigNode<String> serverPropertiesPath = node(ConfigNode.builder("misc.server-properties-path", String.class)
+            .comment("")
             .comment("Change this if you use a custom path for the server.properties file with `--config` startup flag.")
             .comment("Note: this config option needs a server restart to take effect.")
             .defaultValue("server.properties")

--- a/src/main/java/org/mvplugins/multiverse/core/utils/FileUtils.java
+++ b/src/main/java/org/mvplugins/multiverse/core/utils/FileUtils.java
@@ -77,7 +77,7 @@ public final class FileUtils {
      */
     public @Nullable File getServerProperties() {
         if (this.serverProperties == null) {
-            this.serverProperties = findFileFromServerDirectory("server.properties");
+            this.serverProperties = findFileFromServerDirectory(config.getServerPropertiesPath());
             Logging.finer("server.properties: %s", this.serverProperties);
         }
         return this.serverProperties;

--- a/src/test/resources/configs/fresh_config.yml
+++ b/src/test/resources/configs/fresh_config.yml
@@ -54,6 +54,7 @@ event-priority:
 
 misc:
   bukkit-yml-path: bukkit.yml
+  server-properties-path: server.properties
   global-debug: 0
   debug-permissions: false
   silent-start: false


### PR DESCRIPTION
Some people relocate `server.properties`, just like any other config file, eg. `bukkit.yml`.
It was only configurable for `bukkit.yml` though. This PR fixes it.