### PR TITLE
Fix message when delete failed due to invalid world folder

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/world/WorldManager.java
+++ b/src/main/java/org/mvplugins/multiverse/core/world/WorldManager.java
@@ -649,10 +649,16 @@ public final class WorldManager {
      */
     public Attempt<String, DeleteFailureReason> deleteWorld(@NotNull DeleteWorldOptions options) {
         return getLoadedWorld(options.world()).fold(
-                () -> loadWorld(LoadWorldOptions.world(options.world()))
-                        .transform(DeleteFailureReason.LOAD_FAILED)
-                        .mapAttempt(world -> doDeleteWorld(world, options)),
+                () -> loadThenDeleteWorld(options),
                 world -> doDeleteWorld(world, options));
+    }
+
+    private Attempt<String, DeleteFailureReason> loadThenDeleteWorld(@NotNull DeleteWorldOptions options) {
+        return loadWorld(LoadWorldOptions.world(options.world()))
+                .fold(
+                        ignore -> worldActionResult(DeleteFailureReason.LOAD_FAILED, options.world().getName()),
+                        loadedWorld -> doDeleteWorld(loadedWorld, options)
+                );
     }
 
     /**

--- a/src/main/resources/multiverse-core_en.properties
+++ b/src/main/resources/multiverse-core_en.properties
@@ -281,8 +281,8 @@ mv-core.createworld.worldexistunloaded=World '{world}' already exists, but it's 
 mv-core.createworld.worldexistloaded=World '{world}' already exists!
 
 mv-core.deleteworld.worldnonexistent=World '{world}' not found!
-mv-core.deleteworld.loadfailed=Unable to load world '{world}', does the world folder exist?&f You can run '&a/mv remove {world}&f' to remove it from Multiverse, or attempt to load again with '&a/mv load {world}&f'.
-mv-core.deleteworld.worldfoldernotfound=World '{world}' folder not found!
+mv-core.deleteworld.loadfailed=Unable to load world '{world}', is the world folder deleted or corrupted?&f You can run '&a/mv remove {world}&f' to remove it from Multiverse, or attempt to load again with '&a/mv load {world}&f'.
+mv-core.deleteworld.worldfoldernotfound=&cUnable to locate '{world}' folder! You may '&a/mv remove {world}&c' to remove it from Multiverse, and manually delete the folder if it exists.
 mv-core.deleteworld.failedtodeletefolder=Failed to delete world folder '{world}': {error}\n&fSee console for more details.
 
 mv-core.importworld.invalidworldname=World '{world}' contains invalid characters!


### PR DESCRIPTION
When deleting a world that has been deleted externally, it sends: 
```
World 'world_x' folder contents do not seem to be a valid world!
If the server software does something different with world folders, or you are very certain the world is valid, use '--skip-folder-check' flag.
```

It should send this instead:
```
Unable to load world 't', is the world folder deleted or corrupted? You can run '/mv remove t' to remove it from Multiverse, or attempt to load again with '/mv load t'.
```

<!-- artifact-comment-section 3332 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3332](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/17510360428/multiverse-core-pr3332.zip)

<!-- artifact-comment-section 3332 end (DO NOT EDIT ABOVE) -->