### PR TITLE
Pass empty string instead of null for generator id and improve error message

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/world/generators/GeneratorProvider.java
+++ b/src/main/java/org/mvplugins/multiverse/core/world/generators/GeneratorProvider.java
@@ -102,8 +102,12 @@ public final class GeneratorProvider implements Listener {
         } catch (Throwable t) {
             Logging.warning("Plugin %s threw an exception when testing if it is a generator plugin! ",
                     plugin.getName());
-            Logging.warning("This is NOT a bug in Multiverse. Do NOT report this to Multiverse support.");
-            t.printStackTrace();
+            Logging.warning("Error by plugin %s: %s", plugin.getName(), t.getMessage());
+            Logging.warning("This is NOT a bug in Multiverse. Do NOT report this to Multiverse support. " +
+                    "Enable debug mode with `/mv debug 1` to see the full stack trace.");
+            if (coreConfig.getGlobalDebug() >= 1) {
+                t.printStackTrace();
+            }
             // Assume it's a generator plugin since it tried to do something, most likely the id is wrong.
             return true;
         }


### PR DESCRIPTION


<!-- artifact-comment-section 3344 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3344](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/18072566658/multiverse-core-pr3344.zip)

<!-- artifact-comment-section 3344 end (DO NOT EDIT ABOVE) -->