### PR TITLE
Fix spawn location inconsistency

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/world/WorldConfigNodes.java
+++ b/src/main/java/org/mvplugins/multiverse/core/world/WorldConfigNodes.java
@@ -241,8 +241,8 @@ final class WorldConfigNodes {
                 if (!(world instanceof LoadedMultiverseWorld loadedWorld)) return;
                 if (newValue == null || newValue instanceof NullSpawnLocation) return;
                 loadedWorld.getBukkitWorld().peek(bukkitWorld -> {
-                    bukkitWorld.setSpawnLocation(newValue);
                     newValue.setWorld(bukkitWorld);
+                    bukkitWorld.setSpawnLocation(newValue);
                 });
             }));
 


### PR DESCRIPTION
CraftWorld.setSpawnLocation(Location) requires the world in location. https://github.com/PaperMC/Paper/blob/e8c6ba5068287049c890688534963041208c4213/paper-server/src/main/java/org/bukkit/craftbukkit/CraftWorld.java#L338

See #3321