### PR TITLE
Default spawn rate and limit to "unset" instead of server wide's default

### DIFF
--- a/src/test/resources/worlds/default_worlds.yml
+++ b/src/test/resources/worlds/default_worlds.yml
@@ -33,7 +33,47 @@ world:
     z: 48.0
     pitch: 0.0
     yaw: 0.0
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2
 world_nether:
@@ -71,6 +111,46 @@ world_nether:
     z: 48.0
     pitch: 0.0
     yaw: 0.0
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2

--- a/src/test/resources/worlds/delete_worlds.yml
+++ b/src/test/resources/worlds/delete_worlds.yml
@@ -33,6 +33,46 @@ world_nether:
     z: 48.0
     pitch: 0.0
     yaw: 0.0
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2

--- a/src/test/resources/worlds/edgecase_worlds.yml
+++ b/src/test/resources/worlds/edgecase_worlds.yml
@@ -34,11 +34,46 @@ world:
     pitch: 0.0
     yaw: 0.0
   spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
     animal:
       spawn: falSe
       tick-rate: 123
-      spawn-limit: -1
-      exceptions: [cow]
+      spawn-limit: '@unset'
+      exceptions: [ cow ]
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: # should be parsed as list of string
     - a
     - 1
@@ -78,6 +113,46 @@ world_nether:
     z: 48.0
     pitch: 0.0
     yaw: 0.0
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2

--- a/src/test/resources/worlds/migrated_worlds.yml
+++ b/src/test/resources/worlds/migrated_worlds.yml
@@ -34,16 +34,46 @@ world_the_end:
     pitch: 0.0
     yaw: 0.0
   spawning:
-    animal:
-      exceptions: [ ]
-      spawn: true
-      spawn-limit: -1
-      tick-rate: -1
     monster:
       exceptions: [ ]
       spawn: true
-      spawn-limit: -1
-      tick-rate: -1
+      spawn-limit: '@unset'
+      tick-rate: '@bukkit'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@bukkit'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2
 world[dot]a[dot]b:
@@ -82,16 +112,46 @@ world[dot]a[dot]b:
     pitch: 0.0
     yaw: 0.0
   spawning:
-    animal:
-      exceptions: [ ]
-      spawn: true
-      spawn-limit: -1
-      tick-rate: -1
     monster:
       exceptions: [ ]
       spawn: true
-      spawn-limit: -1
-      tick-rate: -1
+      spawn-limit: '@unset'
+      tick-rate: '@bukkit'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@bukkit'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist:
   - test
   version: 1.2
@@ -131,16 +191,46 @@ world[dot]a[dot]c:
     pitch: 0.0
     yaw: 0.0
   spawning:
-    animal:
-      exceptions: [ ]
-      spawn: true
-      spawn-limit: -1
-      tick-rate: -1
     monster:
       exceptions: [ ]
       spawn: true
-      spawn-limit: -1
-      tick-rate: -1
+      spawn-limit: '@unset'
+      tick-rate: '@bukkit'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@bukkit'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist:
     - test
   version: 1.2

--- a/src/test/resources/worlds/newworld_worlds.yml
+++ b/src/test/resources/worlds/newworld_worlds.yml
@@ -33,7 +33,47 @@ world:
     z: 48.0
     pitch: 0.0
     yaw: 0.0
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2
 world_nether:
@@ -71,7 +111,47 @@ world_nether:
     z: 48.0
     pitch: 0.0
     yaw: 0.0
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2
 new[dot]world:
@@ -104,6 +184,46 @@ new[dot]world:
   seed: -9223372036854775808
   spawn-location:
     ==: MVNullLocation (It's a bug if you see this in your config file)
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2

--- a/src/test/resources/worlds/properties_worlds.yml
+++ b/src/test/resources/worlds/properties_worlds.yml
@@ -33,7 +33,47 @@ world:
     z: 48.0
     pitch: 0.0
     yaw: 0.0
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2
 world_nether:
@@ -66,6 +106,46 @@ world_nether:
   seed: -9223372036854775808
   spawn-location:
     ==: MVNullLocation (It's a bug if you see this in your config file)
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2

--- a/src/test/resources/worlds/updated_worlds.yml
+++ b/src/test/resources/worlds/updated_worlds.yml
@@ -34,17 +34,47 @@ world:
     pitch: 0.0
     yaw: 0.0
   spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
     animal:
       spawn: true
       tick-rate: 111
-      spawn-limit: -1
+      spawn-limit: '@unset'
       exceptions:
         - cow
         - pig
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
     misc:
       spawn: false
-      tick-rate: -1
-      spawn-limit: -1
+      tick-rate: '@unset'
+      spawn-limit: '@unset'
       exceptions: [ ]
   world-blacklist: []
   version: 1.2
@@ -83,6 +113,46 @@ world_nether:
     z: 48.0
     pitch: 0.0
     yaw: 0.0
-  spawning: {}
+  spawning:
+    monster:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_animal:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    water_underground_creature:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    ambient:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    axolotl:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
+    misc:
+      exceptions: [ ]
+      spawn: true
+      spawn-limit: '@unset'
+      tick-rate: '@unset'
   world-blacklist: []
   version: 1.2


### PR DESCRIPTION
This should prevent multiverse interfering with paper-world.yml by default.

<!-- artifact-comment-section 3396 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3396](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/20054460332/multiverse-core-pr3396.zip)

<!-- artifact-comment-section 3396 end (DO NOT EDIT ABOVE) -->