### PR TITLE
Update platforms supported version for 1.21.11

### DIFF
--- a/.github/workflows/generic.platform_uploads.yml
+++ b/.github/workflows/generic.platform_uploads.yml
@@ -107,7 +107,7 @@ jobs:
         files: '["${{ github.workspace }}/${{ inputs.plugin_name }}-${{ steps.release-info.outputs.tag_name }}.jar"]'
         name: ${{ steps.release-info.outputs.tag_name }}
         changelog: ${{ steps.release-artifact.outputs.body }}
-        game_versions: 1.21.10, 1.21.9, 1.21.8, 1.21.7, 1.21.6, 1.21.5, 1.21.4, 1.21.3, 1.21.2, 1.21.1, 1.21, 1.20.6, 1.20.5, 1.20.4, 1.20.3, 1.20.2, 1.20.1, 1.20, 1.19.4, 1.19.3, 1.19.2, 1.19.1, 1.19, 1.18.2
+        game_versions: 1.21.11, 1.21.10, 1.21.9, 1.21.8, 1.21.7, 1.21.6, 1.21.5, 1.21.4, 1.21.3, 1.21.2, 1.21.1, 1.21, 1.20.6, 1.20.5, 1.20.4, 1.20.3, 1.20.2, 1.20.1, 1.20, 1.19.4, 1.19.3, 1.19.2, 1.19.1, 1.19, 1.18.2
         version_type: ${{ steps.parse-release-type.outputs.release_type }}
         loaders: bukkit, spigot, paper, purpur
         dependencies: ${{ inputs.modrinth_dependencies }}
@@ -121,7 +121,7 @@ jobs:
         changelog: ${{ steps.release-artifact.outputs.body }}
         changelog_type: markdown
         display_name: ${{ steps.release-info.outputs.tag_name }}
-        game_versions: 1.21.10, 1.21.9, 1.21.8, 1.21.7, 1.21.6, 1.21.5, 1.21.4, 1.21.3, 1.21.2, 1.21.1, 1.21, 1.20.6, 1.20.5, 1.20.4, 1.20.3, 1.20.2, 1.20.1, 1.20, 1.19.4, 1.19.3, 1.19.2, 1.19.1, 1.19, 1.18.2
+        game_versions: 1.21.11, 1.21.10, 1.21.9, 1.21.8, 1.21.7, 1.21.6, 1.21.5, 1.21.4, 1.21.3, 1.21.2, 1.21.1, 1.21, 1.20.6, 1.20.5, 1.20.4, 1.20.3, 1.20.2, 1.20.1, 1.20, 1.19.4, 1.19.3, 1.19.2, 1.19.1, 1.19, 1.18.2
         release_type: ${{ steps.parse-release-type.outputs.release_type }}
         project_relations: ${{ inputs.dbo_project_relations }}
         file_path: ${{ github.workspace }}/${{ inputs.plugin_name }}-${{ steps.release-info.outputs.tag_name }}.jar
@@ -136,5 +136,5 @@ jobs:
         channel: ${{ steps.parse-release-type.outputs.release_type }}
         files: '[{"path": "${{ github.workspace }}/${{ inputs.plugin_name }}-${{ steps.release-info.outputs.tag_name }}.jar", "platforms": ["PAPER"]}]'
         description: ${{ steps.release-artifact.outputs.body }}
-        platform_dependencies: '{"PAPER": ["1.18.2-1.21.10"]}'
+        platform_dependencies: '{"PAPER": ["1.18.2-1.21.11"]}'
         plugin_dependencies: ${{ inputs.hangar_plugin_dependencies }}


### PR DESCRIPTION
This is purely for the plugin site's version labeling/tagging only, mv already supports 1.21.11 without changes.

<!-- artifact-comment-section 3401 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3401](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/20124093144/multiverse-core-pr3401.zip)

<!-- artifact-comment-section 3401 end (DO NOT EDIT ABOVE) -->