### PR TITLE
Fix null error when world name for non-player placeholders not specified

### DIFF
--- a/src/main/java/org/mvplugins/multiverse/core/PlaceholderExpansionHook.java
+++ b/src/main/java/org/mvplugins/multiverse/core/PlaceholderExpansionHook.java
@@ -113,7 +113,7 @@ final class PlaceholderExpansionHook extends PlaceholderExpansion {
                 return Option.of(player.getWorld().getName());
             } else {
                 warning("You must specify a world name for non-player placeholders");
-                return null;
+                return Option.none();
             }
         }
 


### PR DESCRIPTION


<!-- artifact-comment-section 3423 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3423](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/21422277936/multiverse-core-pr3423.zip)

<!-- artifact-comment-section 3423 end (DO NOT EDIT ABOVE) -->