### PR TITLE
Switch to use jitpack for config dep as glare is down

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,13 @@ description = 'Multiverse-Core'
 
 repositories {
     maven {
-        name = 'aikar repo'
-        url = uri('https://repo.aikar.co/content/groups/aikar/')
+        name = 'jitpack repo'
+        url = uri('https://jitpack.io')
     }
 
     maven {
-        name = 'glaremasters repo'
-        url = 'https://repo.glaremasters.me/repository/towny/'
+        name = 'aikar repo'
+        url = uri('https://repo.aikar.co/content/groups/aikar/')
     }
 
     maven {
@@ -43,7 +43,7 @@ dependencies {
     shadowed 'co.aikar:acf-paper:0.5.1-SNAPSHOT'
 
     // Config
-    shadowed('io.github.townyadvanced.commentedconfiguration:CommentedConfiguration:1.0.1') {
+    shadowed('com.github.TownyAdvanced:CommentedConfiguration:1.0.3') {
         exclude group: 'org.spigotmc', module: 'spigot-api'
     }
 


### PR DESCRIPTION


<!-- artifact-comment-section 3507 start (DO NOT EDIT BELOW) -->
----
📦 Artifacts generated:
- [multiverse-core-pr3507](https://nightly.link/Multiverse/Multiverse-Core/actions/runs/30012084464/multiverse-core-pr3507.zip)

<!-- artifact-comment-section 3507 end (DO NOT EDIT ABOVE) -->